### PR TITLE
Fix unsubscribe: add confirmation step and goodbye email

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -892,8 +892,11 @@ def verify_email_subscription(engine, token: str) -> bool:
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
-def unsubscribe_email(engine, token: str) -> bool:
-    """Unsubscribe an email using the unsubscribe token"""
+def unsubscribe_email(engine, token: str) -> Optional[str]:
+    """Unsubscribe an email using the unsubscribe token.
+
+    Returns the email address that was removed, or None if the token was invalid.
+    """
     SessionLocal = sessionmaker(bind=engine, future=True)
     
     with SessionLocal() as session:
@@ -903,12 +906,13 @@ def unsubscribe_email(engine, token: str) -> bool:
         )
         
         if not subscription:
-            return False
+            return None
         
+        email = subscription.email
         stmt = delete(EmailSubscriptionModel).where(EmailSubscriptionModel.unsubscribe_token == token)
         session.execute(stmt)
         session.commit()
-        return True
+        return email
 
 
 BOUNCE_DEACTIVATION_THRESHOLD = 3

--- a/server.py
+++ b/server.py
@@ -306,6 +306,109 @@ def send_verification_email(email: str, verification_token: str) -> bool:
         return False
 
 
+def send_goodbye_email(email: str) -> bool:
+    """Send a goodbye/confirmation email after a user unsubscribes."""
+    email_client = get_email_client()
+    if not email_client:
+        otelLogger.warning("Email client not available for goodbye email")
+        return False
+
+    subscribe_url = f"{EMAIL_BASE_URL}/subscribe"
+
+    html_content = f"""<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width,initial-scale=1'>
+    <title>Unsubscribed - Fabric GPS</title>
+    <style>
+        body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,sans-serif; }}
+    </style>
+</head>
+<body style='margin:0;padding:0;background:#f3f2f1;'>
+    <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='background:#f3f2f1;padding:28px 0;'>
+        <tr>
+            <td align='center' style='padding:0 14px;'>
+                <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='max-width:620px;'>
+                    <tr>
+                        <td style="background:linear-gradient(135deg,#19433c 0%,#286c61 100%);color:#ffffff;border-radius:14px;padding:40px 36px 42px 36px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
+                            <h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>🗺️ Fabric GPS</h1>
+                            <p style='margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);'>You have been unsubscribed from weekly updates.</p>
+                        </td>
+                    </tr>
+                    <tr><td style='height:30px;'></td></tr>
+                    <tr>
+                        <td style='background:#ffffff;border:1px solid #e1e5e9;border-radius:12px;padding:34px 32px;box-shadow:0 1px 2px rgba(0,0,0,0.04),0 4px 10px rgba(0,0,0,0.06);'>
+                            <h2 style='margin:0 0 18px 0;font-size:22px;line-height:1.25;color:#323130;font-weight:600;text-align:center;'>You're Unsubscribed</h2>
+                            <p style='margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#605e5c;text-align:center;'>This confirms that you have been fully removed from the Fabric GPS weekly email list. You will not receive any further emails from us.</p>
+                            <p style='margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#605e5c;text-align:center;'>If you change your mind, you can re-subscribe at any time:</p>
+                            <div style='text-align:center;margin:10px 0 34px 0;'>
+                                <a href='{subscribe_url}' style="background:#19433c;background-image:linear-gradient(90deg,#19433c,#286c61);color:#ffffff;text-decoration:none;padding:14px 26px;font-size:15px;font-weight:600;border-radius:8px;display:inline-block;box-shadow:0 2px 4px rgba(0,0,0,0.18);">Re-subscribe</a>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td style='height:26px;'></td></tr>
+                    <tr>
+                        <td style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:20px 22px;text-align:center;font-size:12px;line-height:1.55;color:#605e5c;'>
+                            <p style='margin:0 0 6px 0;'>This is a one-time confirmation. You will not receive further emails.</p>
+                            <p style='margin:10px 0 0 0;color:#8a8886;'>&copy; Fabric GPS</p>
+                        </td>
+                    </tr>
+                    <tr><td style='height:34px;'></td></tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>"""
+
+    text_content = f"""FABRIC GPS - UNSUBSCRIBE CONFIRMATION
+
+You have been fully unsubscribed from Fabric GPS weekly updates.
+You will not receive any further emails from us.
+
+If you change your mind, you can re-subscribe at any time:
+{subscribe_url}
+
+This is a one-time confirmation. You will not receive further emails.
+
+--
+Fabric GPS
+"""
+
+    message = {
+        "senderAddress": FROM_EMAIL,
+        "recipients": {
+            "to": [{"address": email}]
+        },
+        "content": {
+            "subject": "You've been unsubscribed from Fabric GPS",
+            "plainText": text_content,
+            "html": html_content
+        }
+    }
+
+    try:
+        poller = email_client.begin_send(message)
+
+        def _monitor_send(poller_obj, target_email):
+            try:
+                result = poller_obj.result()
+                status = result.get('status') if isinstance(result, dict) else getattr(result, 'get', lambda *_: None)('status')
+                if status == 'Succeeded':
+                    otelLogger.info(f"Goodbye email sent to {target_email}")
+                else:
+                    otelLogger.warning(f"Goodbye email status for {target_email}: {status}")
+            except Exception as monitor_exc:
+                otelLogger.error(f"Error monitoring goodbye email send to {target_email}: {monitor_exc}")
+
+        threading.Thread(target=_monitor_send, args=(poller, email), daemon=True).start()
+        return True
+    except Exception as e:
+        otelLogger.error(f"Failed to send goodbye email to {email}: {e}")
+        return False
+
+
 def get_engine():
     global ENGINE
     if ENGINE is None:
@@ -801,25 +904,33 @@ def verify_email_page():
     return render_template('verify_email.html', pending=True, token=token)
 
 
-@app.route("/unsubscribe", methods=["GET"])
+@app.route("/unsubscribe", methods=["GET", "POST"])
 def unsubscribe_page():
-    """HTML page for unsubscribing"""
-    token = request.args.get('token')
+    """HTML page for unsubscribing with explicit confirm step.
+    GET: display confirmation page (does NOT unsubscribe).
+    POST: perform unsubscription using token, send goodbye email, then show result.
+    """
+    token = request.values.get('token')
     if not token:
         return render_template('unsubscribe.html', error="Missing unsubscribe token"), 400
-    
-    try:
-        engine = get_engine()
-        success = unsubscribe_email(engine, token)
-        
-        if success:
-            return render_template('unsubscribe.html', success=True)
-        else:
-            return render_template('unsubscribe.html', error="Invalid unsubscribe token")
-            
-    except Exception as e:
-        otelLogger.error(f"Error unsubscribing: {e}")
-        return render_template('unsubscribe.html', error="Failed to unsubscribe"), 500
+
+    if request.method == 'POST':
+        try:
+            engine = get_engine()
+            email = unsubscribe_email(engine, token)
+
+            if email:
+                send_goodbye_email(email)
+                return render_template('unsubscribe.html', success=True)
+            else:
+                return render_template('unsubscribe.html', error="Invalid unsubscribe token")
+
+        except Exception as e:
+            otelLogger.error(f"Error unsubscribing: {e}")
+            return render_template('unsubscribe.html', error="Failed to unsubscribe"), 500
+
+    # GET -> show pending confirmation UI
+    return render_template('unsubscribe.html', pending=True, token=token)
 
 
 @app.get("/api/releases/history/<release_item_id>")

--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -4,7 +4,7 @@
 <meta name="robots" content="noindex, nofollow">
 <style>
     .unsubscribe-container { max-width: 600px; margin: 2rem auto; padding: var(--spacing-xl); background: white; border-radius: 12px; box-shadow: var(--elevation-2); text-align: center; }
-    .success-icon, .error-icon { font-size: 4rem; margin-bottom: var(--spacing-l); }
+    .success-icon, .error-icon, .pending-icon { font-size: 4rem; margin-bottom: var(--spacing-l); }
     .success-message { color: var(--fabric-semantic-success); }
     .error-message { color: var(--fabric-semantic-error); }
 </style>
@@ -12,12 +12,22 @@
 
 {% block content %}
 <div class="unsubscribe-container">
-    {% if success %}
+    {% if pending %}
+        <div class="pending-icon">👋</div>
+        <h1 style="margin-top:0;">Confirm Unsubscribe</h1>
+        <p>Click the button below to unsubscribe from Fabric GPS weekly updates.</p>
+        <form method="POST" style="margin-top:var(--spacing-l);">
+          <input type="hidden" name="token" value="{{ token }}">
+          <button type="submit" class="button button-primary">Unsubscribe</button>
+        </form>
+        <p style="margin-top:var(--spacing-l);font-size:.85rem;color:var(--fabric-neutral-grey-90);">This page does nothing until you press Unsubscribe.</p>
+    {% elif success %}
         <div class="success-icon">✅</div>
         <h1 class="success-message">Successfully Unsubscribed</h1>
         <p>You have been unsubscribed from Fabric GPS weekly updates. We're sorry to see you go!</p>
-        <p>You can subscribe again at any time from our homepage.</p>
-        <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
+        <p>A confirmation email has been sent. You can subscribe again at any time.</p>
+        <a href="/subscribe" class="button button-primary" style="margin-top: var(--spacing-l);">Re-subscribe</a>
+        <a href="/" class="button button-secondary" style="margin-top: var(--spacing-l);">Back to Home</a>
     {% elif error %}
         <div class="error-icon">❌</div>
         <h1 class="error-message">Unsubscribe Failed</h1>


### PR DESCRIPTION
## Problem
The unsubscribe link in weekly emails performs an instant GET-based removal. Automated link scanners in email clients (e.g. Outlook SafeLinks, corporate proxies) follow the link and silently unsubscribe users without their knowledge.

## Changes
- **Confirmation step** - /unsubscribe now uses GET+POST (matching the existing /verify-email pattern). GET shows a confirmation page with an Unsubscribe button; POST performs the actual removal.
- **Goodbye email** - After unsubscribing, a styled confirmation email is sent confirming removal and providing a re-subscribe link.
- **DB change** - unsubscribe_email() now returns the email address (instead of bool) so the goodbye email can be sent.

## Files changed
- server.py - new send_goodbye_email(), updated /unsubscribe route to GET+POST
- db/db_sqlserver.py - unsubscribe_email() returns Optional[str]
- templates/unsubscribe.html - added pending/confirmation state
