### PR TITLE
Email system overhaul: caching, cadence, design, and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 Small Flask server that exposes an RSS 2.0 feed and basic REST API for the Fabric Roadmap
 
+## Email Subscriptions
+
+Subscribers can receive digest emails with customizable options:
+
+- **Cadence**: Daily or Weekly (Mondays)
+- **Content filters**: Filter by product, release type, and/or release status
+- **Feature watches**: Watch individual release items for instant alerts (checked hourly regardless of digest cadence)
+
+### Preferences
+
+Existing subscribers can manage their preferences at `/preferences?token=<unsubscribe_token>`. This link is included in the footer of every email.
+
+### Scheduling
+
+The email job (`APP_MODE=email`) should be scheduled to run **hourly**. It handles both cadences internally:
+- Digest emails are sent when each subscriber's cadence interval has elapsed
+- Feature watch alerts are checked every run
+
+```bash
+# Example cron (every hour at minute 0)
+0 * * * * docker run --rm -e APP_MODE=email -e SQLSERVER_CONN="..." fabric-gps
+```
+
 ## Caching
 
 Caching is handled by Azure Front Door at the CDN edge. The server sets HTTP cache headers on all API and RSS responses:

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -807,12 +807,8 @@ def generate_secure_token() -> str:
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
-def create_email_subscription(engine, email: str, filters: Optional[Dict[str, str]] = None, cadence: str = 'weekly', pending_watch_release_id: Optional[str] = None) -> Tuple[str, str]:
+def create_email_subscription(engine, email: str, filters: Optional[Dict[str, str]] = None, cadence: str = 'weekly') -> Tuple[str, str]:
     """Create an email subscription with verification token.
-    
-    If *pending_watch_release_id* is provided, it is stored on the
-    verification record and the watch will be added automatically
-    when the email is verified.
 
     Returns tuple of (subscription_id, verification_token).
     An empty verification_token means the user is already verified.
@@ -828,9 +824,7 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
         )
         
         if existing and existing.is_verified:
-            # Already subscribed and verified — add watch immediately if requested
-            if pending_watch_release_id:
-                add_feature_watch(engine, existing.id, pending_watch_release_id)
+            # Already subscribed and verified
             return existing.id, ""
         
         verification_token = generate_secure_token()
@@ -869,12 +863,61 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
             token=verification_token,
             action_type='subscribe',
             expires_at=datetime.utcnow() + timedelta(hours=24),
-            pending_watch_release_id=pending_watch_release_id,
         )
         session.add(verification)
         session.commit()
         
         return subscription_id, verification_token
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def create_watch_verification(engine, email: str, release_item_id: str) -> Tuple[Optional[str], str]:
+    """Create a verification record for adding a feature watch.
+
+    If the email is already a verified subscriber, a watch-specific
+    verification record is created. If the email is not subscribed at all,
+    a new subscription is created first (unverified).
+
+    Returns (subscription_id, verification_token). The watch is only added
+    when the user verifies via the token.
+    """
+    SessionLocal = sessionmaker(bind=engine, future=True)
+
+    with SessionLocal() as session:
+        existing = session.scalar(
+            select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == email)
+        )
+
+        if existing and existing.is_verified:
+            subscription_id = existing.id
+        elif existing:
+            # Re-use existing unverified subscription
+            existing.created_at = datetime.utcnow()
+            existing.is_active = True
+            subscription_id = existing.id
+        else:
+            # Create a new subscription (will be verified when token is used)
+            sub = EmailSubscriptionModel(
+                email=email,
+                verification_token=generate_secure_token(),
+                unsubscribe_token=generate_secure_token(),
+            )
+            session.add(sub)
+            session.flush()
+            subscription_id = sub.id
+
+        verification_token = generate_secure_token()
+        verification = EmailVerificationModel(
+            email=email,
+            token=verification_token,
+            action_type='subscribe',
+            expires_at=datetime.utcnow() + timedelta(hours=24),
+            pending_watch_release_id=release_item_id,
+        )
+        session.add(verification)
+        session.commit()
+
+    return subscription_id, verification_token
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -106,6 +106,8 @@ class EmailVerificationModel(Base):
     expires_at = Column(DateTime, nullable=False)
     is_used = Column(Boolean, default=False, nullable=False)
     used_at = Column(DateTime, nullable=True)
+    # Optional: auto-add a feature watch after verification completes
+    pending_watch_release_id = Column(String(36), nullable=True)
 
 
 class EmailContentCacheModel(Base):
@@ -805,10 +807,15 @@ def generate_secure_token() -> str:
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
-def create_email_subscription(engine, email: str, filters: Optional[Dict[str, str]] = None, cadence: str = 'weekly') -> Tuple[str, str]:
+def create_email_subscription(engine, email: str, filters: Optional[Dict[str, str]] = None, cadence: str = 'weekly', pending_watch_release_id: Optional[str] = None) -> Tuple[str, str]:
     """Create an email subscription with verification token.
     
-    Returns tuple of (subscription_id, verification_token)
+    If *pending_watch_release_id* is provided, it is stored on the
+    verification record and the watch will be added automatically
+    when the email is verified.
+
+    Returns tuple of (subscription_id, verification_token).
+    An empty verification_token means the user is already verified.
     """
     if cadence not in ('daily', 'weekly'):
         cadence = 'weekly'
@@ -821,7 +828,9 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
         )
         
         if existing and existing.is_verified:
-            # Already subscribed and verified
+            # Already subscribed and verified — add watch immediately if requested
+            if pending_watch_release_id:
+                add_feature_watch(engine, existing.id, pending_watch_release_id)
             return existing.id, ""
         
         verification_token = generate_secure_token()
@@ -859,7 +868,8 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
             email=email,
             token=verification_token,
             action_type='subscribe',
-            expires_at=datetime.utcnow() + timedelta(hours=24)
+            expires_at=datetime.utcnow() + timedelta(hours=24),
+            pending_watch_release_id=pending_watch_release_id,
         )
         session.add(verification)
         session.commit()
@@ -869,7 +879,11 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def verify_email_subscription(engine, token: str) -> bool:
-    """Verify an email subscription using the verification token"""
+    """Verify an email subscription using the verification token.
+
+    If the verification record has a pending_watch_release_id, the watch
+    is automatically added after successful verification.
+    """
     SessionLocal = sessionmaker(bind=engine, future=True)
     
     with SessionLocal() as session:
@@ -903,8 +917,15 @@ def verify_email_subscription(engine, token: str) -> bool:
         verification.is_used = True
         verification.used_at = datetime.utcnow()
         
+        pending_release_id = verification.pending_watch_release_id
+        
         session.commit()
-        return True
+
+    # Add pending watch outside the verification transaction
+    if pending_release_id:
+        add_feature_watch(engine, subscription.id, pending_release_id)
+
+    return True
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -1102,6 +1102,17 @@ def get_digest_eligible_subscriptions(engine) -> List[EmailSubscriptionModel]:
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_release_item_by_id(engine, release_item_id: str) -> Optional[ReleaseItemModel]:
+    """Return a ReleaseItemModel by primary key, or None if not found."""
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        item = session.get(ReleaseItemModel, release_item_id)
+        if item:
+            session.expunge(item)
+        return item
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def add_feature_watch(engine, subscription_id: str, release_item_id: str) -> bool:
     """Add a feature watch. Returns True if created, False if already exists."""
     SessionLocal = sessionmaker(bind=engine, future=True)
@@ -1264,14 +1275,16 @@ def get_subscriptions_with_changed_watches(engine) -> List[Tuple[EmailSubscripti
 
     Used by the hourly email job to send watch alert emails.
     Returns list of (subscription, [changed_watch_dicts]).
+
+    Uses a single joined query to avoid N+1 DB round-trips.
     """
+    from collections import defaultdict
     SessionLocal = sessionmaker(bind=engine, future=True)
     with SessionLocal() as session:
-        # Find subscriptions that have at least one watch with a hash mismatch
-        sub_ids = session.scalars(
-            select(FeatureWatchModel.subscription_id).distinct()
+        rows = session.execute(
+            select(EmailSubscriptionModel, FeatureWatchModel, ReleaseItemModel)
+            .join(FeatureWatchModel, EmailSubscriptionModel.id == FeatureWatchModel.subscription_id)
             .join(ReleaseItemModel, FeatureWatchModel.release_item_id == ReleaseItemModel.release_item_id)
-            .join(EmailSubscriptionModel, FeatureWatchModel.subscription_id == EmailSubscriptionModel.id)
             .where(EmailSubscriptionModel.is_active == True)
             .where(EmailSubscriptionModel.is_verified == True)
             .where(
@@ -1281,21 +1294,32 @@ def get_subscriptions_with_changed_watches(engine) -> List[Tuple[EmailSubscripti
                 )
             )
         ).all()
-        sub_ids = list(sub_ids)
+
+        subs_by_id: Dict[str, EmailSubscriptionModel] = {}
+        changes_by_sub_id: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+
+        for sub, watch, release in rows:
+            if sub.id not in subs_by_id:
+                subs_by_id[sub.id] = sub
+            changes_by_sub_id[sub.id].append({
+                'watch_id': watch.id,
+                'release_item_id': release.release_item_id,
+                'feature_name': release.feature_name,
+                'product_name': release.product_name,
+                'release_type': release.release_type,
+                'release_status': release.release_status,
+                'feature_description': release.feature_description,
+                'last_modified': release.last_modified.isoformat() if release.last_modified else None,
+                'active': release.active,
+                'current_hash': release.row_hash,
+            })
+
         session.expunge_all()
 
-    results = []
-    for sub_id in sub_ids:
-        SessionLocal2 = sessionmaker(bind=engine, future=True)
-        with SessionLocal2() as session:
-            sub = session.get(EmailSubscriptionModel, sub_id)
-            if not sub:
-                continue
-            session.expunge(sub)
-        changes = get_watched_changes(engine, sub_id)
-        if changes:
-            results.append((sub, changes))
-    return results
+    return [
+        (subs_by_id[sub_id], changes_by_sub_id[sub_id])
+        for sub_id in subs_by_id
+    ]
 
 @retry_on_transient_errors(max_attempts=5, initial_delay=1.0, backoff=2.0, max_delay=60.0)
 def fetch_history_rows(engine, release_item_id: str):

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -71,7 +71,7 @@ class EmailSubscriptionModel(Base):
     is_active = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     verified_at = Column(DateTime, nullable=True)
-    last_email_sent = Column(Date, nullable=True)
+    last_email_sent = Column(DateTime, nullable=True)
     unsubscribe_token = Column(String(64), nullable=False, index=True)
     
     # Optional filters for personalized emails
@@ -112,9 +112,11 @@ class EmailVerificationModel(Base):
 
 class EmailContentCacheModel(Base):
     __tablename__ = "email_content_cache"
-    id = Column(Integer, primary_key=True, default=1)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    cache_date = Column(String(10), nullable=False, index=True)
+    cache_key = Column(String(255), nullable=False)
     generated_at = Column(DateTime, nullable=False)
-    content_json = Column(Text, nullable=False)  # JSON blob: {changes: [...], ai_summary: "..."}
+    content_json = Column(Text, nullable=False)
 
 
 def _is_transient_sql_azure_error(exc: Exception) -> bool:
@@ -961,12 +963,13 @@ def verify_email_subscription(engine, token: str) -> bool:
         verification.used_at = datetime.utcnow()
         
         pending_release_id = verification.pending_watch_release_id
+        subscription_id = subscription.id
         
         session.commit()
 
     # Add pending watch outside the verification transaction
     if pending_release_id:
-        add_feature_watch(engine, subscription.id, pending_release_id)
+        add_feature_watch(engine, subscription_id, pending_release_id)
 
     return True
 
@@ -1086,9 +1089,15 @@ CADENCE_INTERVALS = {
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def get_digest_eligible_subscriptions(engine) -> List[EmailSubscriptionModel]:
-    """Get all subscriptions eligible for a digest email based on their cadence."""
+    """Get all subscriptions eligible for a digest email based on their cadence.
+
+    Weekly subscribers are only eligible on Mondays (UTC).
+    """
+    from datetime import datetime, timezone
     results = []
     for cadence, days in CADENCE_INTERVALS.items():
+        if cadence == 'weekly' and datetime.now(timezone.utc).weekday() != 0:
+            continue
         batch = get_unsent_active_subscriptions(engine, time_frame=days, cadence=cadence)
         results.extend(batch)
     return results
@@ -1184,6 +1193,22 @@ def get_subscription_by_unsubscribe_token(engine, token: str) -> Optional[EmailS
     with SessionLocal() as session:
         sub = session.scalar(
             select(EmailSubscriptionModel).where(EmailSubscriptionModel.unsubscribe_token == token)
+        )
+        if sub:
+            session.expunge(sub)
+        return sub
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_verified_subscription_by_email(engine, email: str) -> Optional[EmailSubscriptionModel]:
+    """Look up a verified, active subscription by email address."""
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        sub = session.scalar(
+            select(EmailSubscriptionModel)
+            .where(EmailSubscriptionModel.email == email.strip().lower())
+            .where(EmailSubscriptionModel.is_verified == True)
+            .where(EmailSubscriptionModel.is_active == True)
         )
         if sub:
             session.expunge(sub)

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -1074,7 +1074,7 @@ def get_unsent_active_subscriptions(engine, time_frame: int, cadence: Optional[s
         )
         if cadence:
             query = query.where(EmailSubscriptionModel.email_cadence == cadence)
-        query = query.limit(100)
+        query = query.limit(1000)
         subscriptions = session.scalars(query).all()
 
         session.expunge_all()

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -1291,8 +1291,9 @@ def get_subscriptions_with_changed_watches(engine) -> List[Tuple[EmailSubscripti
         SessionLocal2 = sessionmaker(bind=engine, future=True)
         with SessionLocal2() as session:
             sub = session.get(EmailSubscriptionModel, sub_id)
-            if sub:
-                session.expunge(sub)
+            if not sub:
+                continue
+            session.expunge(sub)
         changes = get_watched_changes(engine, sub_id)
         if changes:
             results.append((sub, changes))

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -2,6 +2,7 @@ import os
 import json
 import uuid
 import hashlib
+from collections import defaultdict
 from datetime import datetime, date, timedelta
 from typing import Iterable, Any, Tuple, Dict
 import urllib.parse
@@ -1278,7 +1279,6 @@ def get_subscriptions_with_changed_watches(engine) -> List[Tuple[EmailSubscripti
 
     Uses a single joined query to avoid N+1 DB round-trips.
     """
-    from collections import defaultdict
     SessionLocal = sessionmaker(bind=engine, future=True)
     with SessionLocal() as session:
         rows = session.execute(

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -805,11 +805,13 @@ def generate_secure_token() -> str:
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
-def create_email_subscription(engine, email: str, filters: Optional[Dict[str, str]] = None) -> Tuple[str, str]:
+def create_email_subscription(engine, email: str, filters: Optional[Dict[str, str]] = None, cadence: str = 'weekly') -> Tuple[str, str]:
     """Create an email subscription with verification token.
     
     Returns tuple of (subscription_id, verification_token)
     """
+    if cadence not in ('daily', 'weekly'):
+        cadence = 'weekly'
     SessionLocal = sessionmaker(bind=engine, future=True)
     
     with SessionLocal() as session:
@@ -831,6 +833,7 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
             existing.unsubscribe_token = unsubscribe_token
             existing.created_at = datetime.utcnow()
             existing.is_active = True
+            existing.email_cadence = cadence
             if filters:
                 existing.product_filter = filters.get('products', '')
                 existing.release_type_filter = filters.get('types', '')
@@ -842,6 +845,7 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
                 email=email,
                 verification_token=verification_token,
                 unsubscribe_token=unsubscribe_token,
+                email_cadence=cadence,
                 product_filter=filters.get('products', '') if filters else '',
                 release_type_filter=filters.get('types', '') if filters else '',
                 release_status_filter=filters.get('statuses', '') if filters else ''

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -3,7 +3,6 @@ import json
 import uuid
 import hashlib
 from datetime import datetime, date, timedelta
-from datetime import timezone
 from typing import Iterable, Any, Tuple, Dict
 import urllib.parse
 import time
@@ -1068,7 +1067,7 @@ def get_unsent_active_subscriptions(engine, time_frame: int, cadence: Optional[s
             .where(
                 or_(
                     EmailSubscriptionModel.last_email_sent == None,
-                    EmailSubscriptionModel.last_email_sent <= datetime.now(timezone.utc) - timedelta(days=time_frame)
+                    EmailSubscriptionModel.last_email_sent <= datetime.utcnow() - timedelta(days=time_frame)
                 )
             )
         )
@@ -1093,10 +1092,9 @@ def get_digest_eligible_subscriptions(engine) -> List[EmailSubscriptionModel]:
 
     Weekly subscribers are only eligible on Mondays (UTC).
     """
-    from datetime import datetime, timezone
     results = []
     for cadence, days in CADENCE_INTERVALS.items():
-        if cadence == 'weekly' and datetime.now(timezone.utc).weekday() != 0:
+        if cadence == 'weekly' and datetime.utcnow().weekday() != 0:
             continue
         batch = get_unsent_active_subscriptions(engine, time_frame=days, cadence=cadence)
         results.extend(batch)

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -83,6 +83,18 @@ class EmailSubscriptionModel(Base):
     bounce_count = Column(Integer, nullable=False, server_default='0', default=0)
     last_bounced_at = Column(DateTime, nullable=True)
 
+    # Email cadence: 'daily' or 'weekly'
+    email_cadence = Column(String(10), nullable=False, server_default='weekly', default='weekly')
+
+
+class FeatureWatchModel(Base):
+    __tablename__ = "feature_watches"
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    subscription_id = Column(String(36), nullable=False, index=True)
+    release_item_id = Column(String(36), nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    last_notified_hash = Column(String(64), nullable=True)
+
 
 class EmailVerificationModel(Base):
     __tablename__ = "email_verifications"
@@ -971,13 +983,14 @@ def get_active_subscriptions(engine) -> List[EmailSubscriptionModel]:
         return list(subscriptions)
     
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
-def get_unsent_active_subscriptions(engine, time_frame: int) -> List[EmailSubscriptionModel]:
-    """Get all active and verified email subscriptions"""
+def get_unsent_active_subscriptions(engine, time_frame: int, cadence: Optional[str] = None) -> List[EmailSubscriptionModel]:
+    """Get active, verified subscriptions whose last_email_sent is older than time_frame days.
+
+    If *cadence* is provided, only subscriptions matching that cadence are returned.
+    """
     SessionLocal = sessionmaker(bind=engine, future=True)
-    #filter based on last_email_sent is 7 or more days ago
-    # limit to 100 to prevent overwhelming the email service
     with SessionLocal() as session:
-        subscriptions = session.scalars(
+        query = (
             select(EmailSubscriptionModel)
             .where(EmailSubscriptionModel.is_active == True)
             .where(EmailSubscriptionModel.is_verified == True)
@@ -987,12 +1000,210 @@ def get_unsent_active_subscriptions(engine, time_frame: int) -> List[EmailSubscr
                     EmailSubscriptionModel.last_email_sent <= datetime.now(timezone.utc) - timedelta(days=time_frame)
                 )
             )
-            .limit(100)
-        ).all()
-        
-        # Detach from session to avoid lazy loading issues
+        )
+        if cadence:
+            query = query.where(EmailSubscriptionModel.email_cadence == cadence)
+        query = query.limit(100)
+        subscriptions = session.scalars(query).all()
+
         session.expunge_all()
         return list(subscriptions)
+
+
+CADENCE_INTERVALS = {
+    'daily': 1,
+    'weekly': 7,
+}
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_digest_eligible_subscriptions(engine) -> List[EmailSubscriptionModel]:
+    """Get all subscriptions eligible for a digest email based on their cadence."""
+    results = []
+    for cadence, days in CADENCE_INTERVALS.items():
+        batch = get_unsent_active_subscriptions(engine, time_frame=days, cadence=cadence)
+        results.extend(batch)
+    return results
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def add_feature_watch(engine, subscription_id: str, release_item_id: str) -> bool:
+    """Add a feature watch. Returns True if created, False if already exists."""
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        with session.begin():
+            existing = session.scalar(
+                select(FeatureWatchModel).where(
+                    FeatureWatchModel.subscription_id == subscription_id,
+                    FeatureWatchModel.release_item_id == release_item_id,
+                )
+            )
+            if existing:
+                return False
+            session.add(FeatureWatchModel(
+                subscription_id=subscription_id,
+                release_item_id=release_item_id,
+            ))
+    return True
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def remove_feature_watch(engine, subscription_id: str, release_item_id: str) -> bool:
+    """Remove a feature watch. Returns True if deleted, False if not found."""
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        with session.begin():
+            result = session.execute(
+                delete(FeatureWatchModel).where(
+                    FeatureWatchModel.subscription_id == subscription_id,
+                    FeatureWatchModel.release_item_id == release_item_id,
+                )
+            )
+    return (result.rowcount or 0) > 0
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_watched_changes(engine, subscription_id: str) -> List[Dict[str, Any]]:
+    """Return watched releases whose row_hash differs from last_notified_hash."""
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        rows = session.execute(
+            select(FeatureWatchModel, ReleaseItemModel)
+            .join(ReleaseItemModel, FeatureWatchModel.release_item_id == ReleaseItemModel.release_item_id)
+            .where(FeatureWatchModel.subscription_id == subscription_id)
+            .where(
+                or_(
+                    FeatureWatchModel.last_notified_hash == None,
+                    FeatureWatchModel.last_notified_hash != ReleaseItemModel.row_hash,
+                )
+            )
+        ).all()
+        results = []
+        for watch, release in rows:
+            results.append({
+                'watch_id': watch.id,
+                'release_item_id': release.release_item_id,
+                'feature_name': release.feature_name,
+                'product_name': release.product_name,
+                'release_type': release.release_type,
+                'release_status': release.release_status,
+                'feature_description': release.feature_description,
+                'last_modified': release.last_modified.isoformat() if release.last_modified else None,
+                'active': release.active,
+                'current_hash': release.row_hash,
+            })
+        return results
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def update_watch_hashes(engine, hash_updates: List[Tuple[str, str]]):
+    """Update last_notified_hash for a list of (watch_id, new_hash) tuples."""
+    if not hash_updates:
+        return
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        with session.begin():
+            for watch_id, new_hash in hash_updates:
+                watch = session.get(FeatureWatchModel, watch_id)
+                if watch:
+                    watch.last_notified_hash = new_hash
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_subscription_by_unsubscribe_token(engine, token: str) -> Optional[EmailSubscriptionModel]:
+    """Look up a subscription by its unsubscribe_token."""
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        sub = session.scalar(
+            select(EmailSubscriptionModel).where(EmailSubscriptionModel.unsubscribe_token == token)
+        )
+        if sub:
+            session.expunge(sub)
+        return sub
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def update_subscription_preferences(engine, token: str, preferences: Dict[str, Any]) -> bool:
+    """Update subscription preferences identified by unsubscribe_token.
+
+    Accepted keys in *preferences*: email_cadence, product_filter, release_type_filter, release_status_filter.
+    Returns True if subscription found and updated.
+    """
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    allowed_keys = {'email_cadence', 'product_filter', 'release_type_filter', 'release_status_filter'}
+    with SessionLocal() as session:
+        with session.begin():
+            sub = session.scalar(
+                select(EmailSubscriptionModel).where(EmailSubscriptionModel.unsubscribe_token == token)
+            )
+            if not sub:
+                return False
+            for key, value in preferences.items():
+                if key in allowed_keys:
+                    setattr(sub, key, value)
+    return True
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_feature_watches_for_subscription(engine, subscription_id: str) -> List[Dict[str, Any]]:
+    """Return all feature watches for a subscription with release details."""
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        rows = session.execute(
+            select(FeatureWatchModel, ReleaseItemModel.feature_name, ReleaseItemModel.product_name)
+            .join(ReleaseItemModel, FeatureWatchModel.release_item_id == ReleaseItemModel.release_item_id)
+            .where(FeatureWatchModel.subscription_id == subscription_id)
+            .order_by(FeatureWatchModel.created_at.desc())
+        ).all()
+        return [
+            {
+                'watch_id': w.id,
+                'release_item_id': w.release_item_id,
+                'feature_name': name,
+                'product_name': product,
+                'created_at': w.created_at.isoformat() if w.created_at else None,
+            }
+            for w, name, product in rows
+        ]
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_subscriptions_with_changed_watches(engine) -> List[Tuple[EmailSubscriptionModel, List[Dict[str, Any]]]]:
+    """Return all active, verified subscribers that have watched features with hash mismatches.
+
+    Used by the hourly email job to send watch alert emails.
+    Returns list of (subscription, [changed_watch_dicts]).
+    """
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        # Find subscriptions that have at least one watch with a hash mismatch
+        sub_ids = session.scalars(
+            select(FeatureWatchModel.subscription_id).distinct()
+            .join(ReleaseItemModel, FeatureWatchModel.release_item_id == ReleaseItemModel.release_item_id)
+            .join(EmailSubscriptionModel, FeatureWatchModel.subscription_id == EmailSubscriptionModel.id)
+            .where(EmailSubscriptionModel.is_active == True)
+            .where(EmailSubscriptionModel.is_verified == True)
+            .where(
+                or_(
+                    FeatureWatchModel.last_notified_hash == None,
+                    FeatureWatchModel.last_notified_hash != ReleaseItemModel.row_hash,
+                )
+            )
+        ).all()
+        sub_ids = list(sub_ids)
+        session.expunge_all()
+
+    results = []
+    for sub_id in sub_ids:
+        SessionLocal2 = sessionmaker(bind=engine, future=True)
+        with SessionLocal2() as session:
+            sub = session.get(EmailSubscriptionModel, sub_id)
+            if sub:
+                session.expunge(sub)
+        changes = get_watched_changes(engine, sub_id)
+        if changes:
+            results.append((sub, changes))
+    return results
 
 @retry_on_transient_errors(max_attempts=5, initial_delay=1.0, backoff=2.0, max_delay=60.0)
 def fetch_history_rows(engine, release_item_id: str):

--- a/migrations/versions/add_cadence_and_watches.py
+++ b/migrations/versions/add_cadence_and_watches.py
@@ -32,11 +32,11 @@ def upgrade():
         IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'feature_watches')
         BEGIN
             CREATE TABLE feature_watches (
-                id NVARCHAR(36) NOT NULL PRIMARY KEY,
-                subscription_id NVARCHAR(36) NOT NULL,
-                release_item_id NVARCHAR(36) NOT NULL,
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                subscription_id VARCHAR(36) NOT NULL,
+                release_item_id VARCHAR(36) NOT NULL,
                 created_at DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
-                last_notified_hash NVARCHAR(64) NULL,
+                last_notified_hash VARCHAR(64) NULL,
                 CONSTRAINT fk_feature_watches_subscription
                     FOREIGN KEY (subscription_id) REFERENCES email_subscriptions(id)
                     ON DELETE CASCADE,

--- a/migrations/versions/add_cadence_and_watches.py
+++ b/migrations/versions/add_cadence_and_watches.py
@@ -1,0 +1,78 @@
+"""add email_cadence column and feature_watches table
+
+Revision ID: add_cadence_and_watches
+Revises: add_version_index
+Create Date: 2026-04-13 19:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_cadence_and_watches'
+down_revision = 'add_version_index'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add email_cadence column to email_subscriptions
+    op.execute("""
+        IF NOT EXISTS (SELECT * FROM sys.columns
+                       WHERE object_id = OBJECT_ID('email_subscriptions')
+                       AND name = 'email_cadence')
+        BEGIN
+            ALTER TABLE email_subscriptions ADD email_cadence VARCHAR(10) NOT NULL DEFAULT 'weekly'
+        END
+    """)
+
+    # Create feature_watches table
+    op.execute("""
+        IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'feature_watches')
+        BEGIN
+            CREATE TABLE feature_watches (
+                id NVARCHAR(36) NOT NULL PRIMARY KEY,
+                subscription_id NVARCHAR(36) NOT NULL,
+                release_item_id NVARCHAR(36) NOT NULL,
+                created_at DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
+                last_notified_hash NVARCHAR(64) NULL,
+                CONSTRAINT fk_feature_watches_subscription
+                    FOREIGN KEY (subscription_id) REFERENCES email_subscriptions(id)
+                    ON DELETE CASCADE,
+                CONSTRAINT fk_feature_watches_release
+                    FOREIGN KEY (release_item_id) REFERENCES release_items(release_item_id),
+                CONSTRAINT uq_feature_watches_sub_release
+                    UNIQUE (subscription_id, release_item_id)
+            )
+        END
+    """)
+
+    # Index on release_item_id for efficient lookups during email job
+    op.execute("""
+        IF NOT EXISTS (SELECT * FROM sys.indexes
+                       WHERE name = 'ix_feature_watches_release_item_id'
+                       AND object_id = OBJECT_ID('feature_watches'))
+        BEGIN
+            CREATE INDEX ix_feature_watches_release_item_id
+                ON feature_watches(release_item_id)
+        END
+    """)
+
+
+def downgrade():
+    op.execute("""
+        IF EXISTS (SELECT * FROM sys.tables WHERE name = 'feature_watches')
+        BEGIN
+            DROP TABLE feature_watches
+        END
+    """)
+
+    op.execute("""
+        IF EXISTS (SELECT * FROM sys.columns
+                   WHERE object_id = OBJECT_ID('email_subscriptions')
+                   AND name = 'email_cadence')
+        BEGIN
+            ALTER TABLE email_subscriptions DROP COLUMN email_cadence
+        END
+    """)

--- a/migrations/versions/add_pending_watch_col.py
+++ b/migrations/versions/add_pending_watch_col.py
@@ -22,7 +22,7 @@ def upgrade():
                        WHERE object_id = OBJECT_ID('email_verifications')
                        AND name = 'pending_watch_release_id')
         BEGIN
-            ALTER TABLE email_verifications ADD pending_watch_release_id NVARCHAR(36) NULL
+            ALTER TABLE email_verifications ADD pending_watch_release_id VARCHAR(36) NULL
         END
     """)
 

--- a/migrations/versions/add_pending_watch_col.py
+++ b/migrations/versions/add_pending_watch_col.py
@@ -1,0 +1,38 @@
+"""add pending_watch_release_id to email_verifications
+
+Revision ID: add_pending_watch_col
+Revises: add_cadence_and_watches
+Create Date: 2026-04-13 21:25:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_pending_watch_col'
+down_revision = 'add_cadence_and_watches'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        IF NOT EXISTS (SELECT * FROM sys.columns
+                       WHERE object_id = OBJECT_ID('email_verifications')
+                       AND name = 'pending_watch_release_id')
+        BEGIN
+            ALTER TABLE email_verifications ADD pending_watch_release_id NVARCHAR(36) NULL
+        END
+    """)
+
+
+def downgrade():
+    op.execute("""
+        IF EXISTS (SELECT * FROM sys.columns
+                   WHERE object_id = OBJECT_ID('email_verifications')
+                   AND name = 'pending_watch_release_id')
+        BEGIN
+            ALTER TABLE email_verifications DROP COLUMN pending_watch_release_id
+        END
+    """)

--- a/migrations/versions/rebuild_email_content_cache.py
+++ b/migrations/versions/rebuild_email_content_cache.py
@@ -53,7 +53,7 @@ def downgrade():
         CREATE TABLE [dbo].[email_content_cache](
             [id] INT NOT NULL DEFAULT 1,
             [generated_at] DATETIME2 NOT NULL,
-            [content_json] NVARCHAR(MAX) NOT NULL,
+            [content_json] NVARCHAR(MAX) NOT NULL
         PRIMARY KEY CLUSTERED ([id] ASC),
         CONSTRAINT [ck_email_content_cache_singleton] CHECK ([id] = 1)
         )

--- a/migrations/versions/rebuild_email_content_cache.py
+++ b/migrations/versions/rebuild_email_content_cache.py
@@ -1,0 +1,60 @@
+"""rebuild email_content_cache with per-date per-filter keying
+
+Revision ID: rebuild_email_content_cache
+Revises: upgrade_last_email_sent
+Create Date: 2026-04-14 19:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'rebuild_email_content_cache'
+down_revision = 'upgrade_last_email_sent'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop old singleton cache table and recreate with composite key
+    op.execute("""
+        IF EXISTS (SELECT * FROM sys.tables WHERE name = 'email_content_cache')
+        BEGIN
+            DROP TABLE email_content_cache
+        END
+    """)
+
+    op.execute("""
+        CREATE TABLE email_content_cache (
+            id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+            cache_date VARCHAR(10) NOT NULL,
+            cache_key VARCHAR(255) NOT NULL,
+            generated_at DATETIME2 NOT NULL,
+            content_json NVARCHAR(MAX) NOT NULL,
+            CONSTRAINT uq_email_cache_date_key UNIQUE (cache_date, cache_key)
+        )
+    """)
+
+    op.execute("""
+        CREATE INDEX ix_email_content_cache_date ON email_content_cache(cache_date)
+    """)
+
+
+def downgrade():
+    op.execute("""
+        IF EXISTS (SELECT * FROM sys.tables WHERE name = 'email_content_cache')
+        BEGIN
+            DROP TABLE email_content_cache
+        END
+    """)
+
+    op.execute("""
+        CREATE TABLE [dbo].[email_content_cache](
+            [id] INT NOT NULL DEFAULT 1,
+            [generated_at] DATETIME2 NOT NULL,
+            [content_json] NVARCHAR(MAX) NOT NULL,
+        PRIMARY KEY CLUSTERED ([id] ASC),
+        CONSTRAINT [ck_email_content_cache_singleton] CHECK ([id] = 1)
+        )
+    """)

--- a/migrations/versions/upgrade_last_email_sent_to_datetime.py
+++ b/migrations/versions/upgrade_last_email_sent_to_datetime.py
@@ -1,7 +1,7 @@
 """upgrade last_email_sent from DATE to DATETIME2
 
 Revision ID: upgrade_last_email_sent
-Revises: add_cadence_and_watches
+Revises: add_pending_watch_col
 Create Date: 2026-04-14 19:00:00.000000
 
 """

--- a/migrations/versions/upgrade_last_email_sent_to_datetime.py
+++ b/migrations/versions/upgrade_last_email_sent_to_datetime.py
@@ -1,0 +1,40 @@
+"""upgrade last_email_sent from DATE to DATETIME2
+
+Revision ID: upgrade_last_email_sent
+Revises: add_cadence_and_watches
+Create Date: 2026-04-14 19:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'upgrade_last_email_sent'
+down_revision = 'add_pending_watch_col'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        IF EXISTS (SELECT * FROM sys.columns
+                   WHERE object_id = OBJECT_ID('email_subscriptions')
+                   AND name = 'last_email_sent'
+                   AND system_type_id = (SELECT system_type_id FROM sys.types WHERE name = 'date'))
+        BEGIN
+            ALTER TABLE email_subscriptions ALTER COLUMN last_email_sent DATETIME2 NULL
+        END
+    """)
+
+
+def downgrade():
+    op.execute("""
+        IF EXISTS (SELECT * FROM sys.columns
+                   WHERE object_id = OBJECT_ID('email_subscriptions')
+                   AND name = 'last_email_sent'
+                   AND system_type_id = (SELECT system_type_id FROM sys.types WHERE name = 'datetime2'))
+        BEGIN
+            ALTER TABLE email_subscriptions ALTER COLUMN last_email_sent DATE NULL
+        END
+    """)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask>=3.0.0
+Flask-Limiter>=3.5.0
 SQLAlchemy>=2.0.0
 pyodbc>=4.0.39
 unidecode>=1.3.8

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from datetime import datetime, date, time, timezone
 from typing import Optional, List
 
 from flask import Flask, request, Response, jsonify, render_template, redirect, send_from_directory
+from flask_limiter import Limiter
 from html import escape
 from email.utils import format_datetime
 import hashlib
@@ -101,6 +102,51 @@ REDIRECT_HOSTS = {h.strip() for h in os.getenv('REDIRECT_HOSTS', '').split(',') 
 EMAIL_BASE_URL = f"https://{CANONICAL_HOST}" if CANONICAL_HOST else BASE_URL
 
 _NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/preferences", "/watch/", "/api/subscribe", "/api/verify-email", "/api/preferences", "/api/watch", "/api/send-preferences-link", "/dev/")
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting (per-worker in-memory; effective behind Azure Front Door)
+# ---------------------------------------------------------------------------
+def _get_real_ip():
+    """Get real client IP from X-Forwarded-For header (set by Azure Front Door)."""
+    forwarded = request.headers.get('X-Forwarded-For', '')
+    if forwarded:
+        return forwarded.split(',')[0].strip()
+    return request.remote_addr or '127.0.0.1'
+
+
+limiter = Limiter(
+    key_func=_get_real_ip,
+    app=app,
+    default_limits=[],
+    storage_uri="memory://",
+)
+
+
+# ---------------------------------------------------------------------------
+# CSRF protection for form-based POST endpoints
+# ---------------------------------------------------------------------------
+_CSRF_FORM_PATHS = ('/verify-email', '/unsubscribe', '/watch/')
+
+
+@app.before_request
+def validate_form_origin():
+    """Reject cross-origin form POST submissions.
+
+    JSON API endpoints are inherently CSRF-safe because browsers cannot
+    send Content-Type: application/json cross-origin without a CORS
+    preflight. This check only targets HTML form POSTs.
+    """
+    if request.method != 'POST':
+        return
+    if not request.path.startswith(_CSRF_FORM_PATHS):
+        return
+    if request.content_type and 'application/json' in request.content_type:
+        return
+    origin = request.headers.get('Origin', '')
+    if origin and not origin.startswith(EMAIL_BASE_URL) and not origin.startswith(BASE_URL):
+        otelLogger.warning(f"Blocked cross-origin form POST from {origin} to {request.path}")
+        return Response("Forbidden: cross-origin form submission", status=403)
 
 
 @app.after_request
@@ -967,6 +1013,7 @@ def api_version():
 
 
 @app.route("/api/subscribe", methods=["POST"])
+@limiter.limit("5 per hour")
 def api_subscribe():
     """Subscribe to weekly email updates"""
     data = request.get_json()
@@ -1023,6 +1070,7 @@ def api_subscribe():
 
 
 @app.route("/api/send-preferences-link", methods=["POST"])
+@limiter.limit("3 per hour")
 def api_send_preferences_link():
     """Send an email with a link to manage subscription preferences.
 
@@ -1073,6 +1121,7 @@ def api_verify_email():
 
 
 @app.route("/verify-email", methods=["GET", "POST"])
+@limiter.limit("10 per hour", methods=["POST"])
 def verify_email_page():
     """HTML page for email verification with explicit confirm step.
     GET: display confirmation page (does NOT verify).
@@ -1123,6 +1172,7 @@ def verify_email_page():
 
 
 @app.route("/unsubscribe", methods=["GET", "POST"])
+@limiter.limit("10 per hour", methods=["POST"])
 def unsubscribe_page():
     """HTML page for unsubscribing with explicit confirm step.
     GET: display confirmation page (does NOT unsubscribe).
@@ -1302,6 +1352,7 @@ def release_detail(release_item_id):
 
 
 @app.route("/watch/<release_item_id>", methods=["GET", "POST"])
+@limiter.limit("5 per hour", methods=["POST"])
 def watch_feature_page(release_item_id):
     """Page to subscribe to watch alerts for a specific release item."""
     engine = get_engine()

--- a/server.py
+++ b/server.py
@@ -38,6 +38,7 @@ from db.db_sqlserver import (
     VALID_SORT_OPTIONS,
     get_changelog_with_changes,
     get_subscription_by_unsubscribe_token, update_subscription_preferences,
+    get_verified_subscription_by_email,
     add_feature_watch, remove_feature_watch, get_feature_watches_for_subscription,
     create_watch_verification,
 )
@@ -99,7 +100,7 @@ REDIRECT_HOSTS = {h.strip() for h in os.getenv('REDIRECT_HOSTS', '').split(',') 
 # Use canonical host for email URLs if configured, otherwise fall back to BASE_URL
 EMAIL_BASE_URL = f"https://{CANONICAL_HOST}" if CANONICAL_HOST else BASE_URL
 
-_NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/preferences", "/watch/", "/api/subscribe", "/api/verify-email", "/api/preferences", "/api/watch")
+_NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/preferences", "/watch/", "/api/subscribe", "/api/verify-email", "/api/preferences", "/api/watch", "/api/send-preferences-link", "/dev/")
 
 
 @app.after_request
@@ -169,7 +170,8 @@ def get_email_client():
     return EMAIL_CLIENT
 
 
-def send_verification_email(email: str, verification_token: str) -> bool:
+def send_verification_email(email: str, verification_token: str,
+                            cadence: str = 'weekly', watch_feature_name: Optional[str] = None) -> bool:
     """Send verification email using Azure Communication Services"""
     email_client = get_email_client()
     if not email_client:
@@ -179,7 +181,31 @@ def send_verification_email(email: str, verification_token: str) -> bool:
     try:
         verification_url = f"{EMAIL_BASE_URL}/verify-email?token={verification_token}"
 
-        # HTML email content (restyled to match weekly email design language)
+        # Build context-aware copy
+        is_watch = bool(watch_feature_name)
+        if is_watch:
+            preheader = f"Verify your email to start watching {watch_feature_name}."
+            hero_text = "Verify your email to start watching a feature on the Microsoft Fabric roadmap."
+            subject = f"Verify your email to watch {watch_feature_name} — Fabric GPS"
+            heading = "Start Watching a Feature"
+            body_text = (
+                f"You requested to watch <strong>{watch_feature_name}</strong> on the Fabric roadmap. "
+                f"Click the button below to confirm your email and start receiving alerts when this feature changes."
+            )
+            after_text = "After verifying, you&rsquo;ll be notified whenever this feature is updated on the roadmap."
+        else:
+            cadence_desc = "daily updates" if cadence == "daily" else "weekly updates every Monday"
+            preheader = f"Confirm your email to start {cadence_desc}."
+            hero_text = f"Verify your email to begin receiving {cadence_desc} about Microsoft Fabric roadmap changes."
+            subject = f"Verify your email for Fabric GPS {cadence_desc}"
+            heading = "Confirm Your Subscription"
+            body_text = (
+                f"Thanks for signing up! One quick step: click the button below to confirm this address "
+                f"and activate {cadence_desc}."
+            )
+            after_text = f"After verifying, you&rsquo;ll receive {cadence_desc} with the latest Microsoft Fabric roadmap changes. No spam &mdash; unsubscribe anytime."
+
+        # HTML email content
         html_content = f"""<!DOCTYPE html>
 <html lang='en'>
 <head>
@@ -191,31 +217,31 @@ def send_verification_email(email: str, verification_token: str) -> bool:
     </style>
 </head>
 <body style='margin:0;padding:0;background:#f3f2f1;'>
-    <span style="display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;color:transparent;">Confirm your email to start weekly Fabric roadmap updates.</span>
+    <span style="display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;color:transparent;">{preheader}</span>
     <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='background:#f3f2f1;padding:28px 0;'>
         <tr>
             <td align='center' style='padding:0 14px;'>
                 <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='max-width:620px;'>
                     <tr>
                         <td style="background:linear-gradient(135deg,#19433c 0%,#286c61 100%);color:#ffffff;border-radius:14px;padding:40px 36px 42px 36px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
-                            <h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>🗺️ Fabric GPS</h1>
-                            <p style='margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);'>Verify your email to begin receiving weekly Microsoft Fabric roadmap change summaries.</p>
+                            <h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>Fabric GPS</h1>
+                            <p style='margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);'>{hero_text}</p>
                         </td>
                     </tr>
                     <tr><td style='height:30px;'></td></tr>
                     <tr>
                         <td style='background:#ffffff;border:1px solid #e1e5e9;border-radius:12px;padding:34px 32px;box-shadow:0 1px 2px rgba(0,0,0,0.04),0 4px 10px rgba(0,0,0,0.06);'>
-                            <h2 style='margin:0 0 18px 0;font-size:22px;line-height:1.25;color:#323130;font-weight:600;text-align:center;'>Confirm Your Email Address</h2>
-                            <p style='margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#605e5c;text-align:center;'>Thanks for signing up! One quick step: click the button below to confirm this address. Then every Monday you will get a concise, styled summary of roadmap item changes from the past week.</p>
+                            <h2 style='margin:0 0 18px 0;font-size:22px;line-height:1.25;color:#323130;font-weight:600;text-align:center;'>{heading}</h2>
+                            <p style='margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#605e5c;text-align:center;'>{body_text}</p>
                             <div style='text-align:center;margin:10px 0 34px 0;'>
                                 <a href='{verification_url}' style="background:#19433c;background-image:linear-gradient(90deg,#19433c,#286c61);color:#ffffff;text-decoration:none;padding:14px 26px;font-size:15px;font-weight:600;border-radius:8px;display:inline-block;box-shadow:0 2px 4px rgba(0,0,0,0.18);">Verify Email</a>
                             </div>
-                            <p style='margin:0 0 18px 0;font-size:13px;line-height:1.5;color:#605e5c;text-align:center;'>If the button doesn't work, copy & paste this link:</p>
+                            <p style='margin:0 0 18px 0;font-size:13px;line-height:1.5;color:#605e5c;text-align:center;'>If the button doesn't work, copy &amp; paste this link:</p>
                             <p style='word-break:break-all;margin:0 0 26px 0;font-size:12px;line-height:1.4;text-align:center;'>
                                 <a href='{verification_url}' style='color:#19433c;text-decoration:none;'>{verification_url}</a>
                             </p>
                             <div style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:16px 18px;'>
-                                <p style='margin:0;font-size:13px;line-height:1.5;color:#605e5c;'>After verifying, you'll get one email per week (Mondays). No spam &mdash; unsubscribe anytime from those emails.</p>
+                                <p style='margin:0;font-size:13px;line-height:1.5;color:#605e5c;'>{after_text}</p>
                             </div>
                         </td>
                     </tr>
@@ -224,7 +250,7 @@ def send_verification_email(email: str, verification_token: str) -> bool:
                         <td style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:20px 22px;text-align:center;font-size:12px;line-height:1.55;color:#605e5c;'>
                             <p style='margin:0 0 6px 0;'>This verification link expires in 24 hours.</p>
                             <p style='margin:0 0 6px 0;'>If you didn't request this, ignore the message and you won't be subscribed.</p>
-                            <p style='margin:10px 0 0 0;color:#8a8886;'>© Fabric GPS</p>
+                            <p style='margin:10px 0 0 0;color:#8a8886;'>&copy; Fabric GPS</p>
                         </td>
                     </tr>
                     <tr><td style='height:34px;'></td></tr>
@@ -236,22 +262,39 @@ def send_verification_email(email: str, verification_token: str) -> bool:
 </html>"""
 
         # Plain text content
-        text_content = f"""
-            FABRIC GPS - EMAIL VERIFICATION
-            
-            Thank you for subscribing to Fabric GPS weekly updates!
-            
-            Please verify your email address by clicking the link below:
-            {verification_url}
-            
-            Once verified, you'll receive weekly emails with the latest Microsoft Fabric roadmap changes.
-            
-            This verification link will expire in 24 hours.
-            If you didn't subscribe to Fabric GPS, you can safely ignore this email.
-            
-            --
-            Fabric GPS Team
-        """
+        if is_watch:
+            text_content = f"""FABRIC GPS - VERIFY YOUR EMAIL
+
+You requested to watch {watch_feature_name} on the Fabric roadmap.
+
+Please verify your email address by clicking the link below:
+{verification_url}
+
+Once verified, you'll be notified whenever this feature is updated.
+
+This verification link will expire in 24 hours.
+If you didn't request this, you can safely ignore this email.
+
+--
+Fabric GPS
+"""
+        else:
+            cadence_text = "daily updates" if cadence == "daily" else "weekly updates"
+            text_content = f"""FABRIC GPS - VERIFY YOUR EMAIL
+
+Thank you for subscribing to Fabric GPS {cadence_text}!
+
+Please verify your email address by clicking the link below:
+{verification_url}
+
+Once verified, you'll receive {cadence_text} with the latest Microsoft Fabric roadmap changes.
+
+This verification link will expire in 24 hours.
+If you didn't subscribe to Fabric GPS, you can safely ignore this email.
+
+--
+Fabric GPS
+"""
         
         message = {
             "senderAddress": FROM_EMAIL,
@@ -309,6 +352,119 @@ def send_verification_email(email: str, verification_token: str) -> bool:
         return False
 
 
+def send_preferences_link_email(email: str, preferences_url: str) -> bool:
+    """Send an email with a link to manage subscription preferences."""
+    email_client = get_email_client()
+    if not email_client:
+        otelLogger.error("Email client not available for preferences link email")
+        return False
+
+    try:
+        html_content = f"""<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width,initial-scale=1'>
+    <title>Manage Your Subscription - Fabric GPS</title>
+    <style>
+        body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,sans-serif; }}
+    </style>
+</head>
+<body style='margin:0;padding:0;background:#f3f2f1;'>
+    <span style="display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;color:transparent;">Your Fabric GPS preferences link is inside.</span>
+    <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='background:#f3f2f1;padding:28px 0;'>
+        <tr>
+            <td align='center' style='padding:0 14px;'>
+                <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='max-width:620px;'>
+                    <tr>
+                        <td style="background:linear-gradient(135deg,#19433c 0%,#286c61 100%);color:#ffffff;border-radius:14px;padding:40px 36px 42px 36px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
+                            <h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>Fabric GPS</h1>
+                            <p style='margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);'>Manage your subscription preferences</p>
+                        </td>
+                    </tr>
+                    <tr><td style='height:30px;'></td></tr>
+                    <tr>
+                        <td style='background:#ffffff;border:1px solid #e1e5e9;border-radius:12px;padding:34px 32px;box-shadow:0 1px 2px rgba(0,0,0,0.04),0 4px 10px rgba(0,0,0,0.06);'>
+                            <h2 style='margin:0 0 18px 0;font-size:22px;line-height:1.25;color:#323130;font-weight:600;text-align:center;'>Your Preferences Link</h2>
+                            <p style='margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#605e5c;text-align:center;'>Click the button below to manage your Fabric GPS subscription &mdash; update your email cadence, filters, and feature watches.</p>
+                            <div style='text-align:center;margin:10px 0 34px 0;'>
+                                <a href='{preferences_url}' style="background:#19433c;background-image:linear-gradient(90deg,#19433c,#286c61);color:#ffffff;text-decoration:none;padding:14px 26px;font-size:15px;font-weight:600;border-radius:8px;display:inline-block;box-shadow:0 2px 4px rgba(0,0,0,0.18);">Manage Preferences</a>
+                            </div>
+                            <p style='margin:0 0 18px 0;font-size:13px;line-height:1.5;color:#605e5c;text-align:center;'>If the button doesn't work, copy &amp; paste this link:</p>
+                            <p style='word-break:break-all;margin:0 0 26px 0;font-size:12px;line-height:1.4;text-align:center;'>
+                                <a href='{preferences_url}' style='color:#19433c;text-decoration:none;'>{preferences_url}</a>
+                            </p>
+                            <div style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:16px 18px;'>
+                                <p style='margin:0;font-size:13px;line-height:1.5;color:#605e5c;'>Keep this link private &mdash; anyone with it can change your subscription settings.</p>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td style='height:26px;'></td></tr>
+                    <tr>
+                        <td style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:20px 22px;text-align:center;font-size:12px;line-height:1.55;color:#605e5c;'>
+                            <p style='margin:0 0 6px 0;'>If you didn't request this, you can safely ignore this email.</p>
+                            <p style='margin:10px 0 0 0;color:#8a8886;'>&copy; Fabric GPS</p>
+                        </td>
+                    </tr>
+                    <tr><td style='height:34px;'></td></tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>"""
+
+        text_content = f"""FABRIC GPS - MANAGE YOUR SUBSCRIPTION
+
+Click the link below to manage your Fabric GPS subscription preferences:
+{preferences_url}
+
+You can update your email cadence, product filters, and feature watches.
+
+Keep this link private - anyone with it can change your subscription settings.
+If you didn't request this, you can safely ignore this email.
+
+--
+Fabric GPS
+"""
+
+        message = {
+            "senderAddress": FROM_EMAIL,
+            "recipients": {
+                "to": [{"address": email}]
+            },
+            "content": {
+                "subject": "Manage your Fabric GPS subscription",
+                "plainText": text_content,
+                "html": html_content
+            }
+        }
+
+        try:
+            poller = email_client.begin_send(message)
+        except Exception as e:
+            otelLogger.error(f"Failed to send preferences link email to {email}: {e}")
+            return False
+
+        def _monitor_send(poller_obj, target_email):
+            try:
+                result = poller_obj.result()
+                status = result.get('status') if isinstance(result, dict) else None
+                if status == 'Succeeded':
+                    otelLogger.info(f"Preferences link email sent to {target_email}")
+                else:
+                    otelLogger.warning(f"Preferences link email status for {target_email}: {status}")
+            except Exception as monitor_exc:
+                otelLogger.error(f"Error monitoring preferences link email to {target_email}: {monitor_exc}")
+
+        threading.Thread(target=_monitor_send, args=(poller, email), daemon=True).start()
+        return True
+
+    except Exception as e:
+        otelLogger.error(f"Error sending preferences link email to {email}: {e}")
+        return False
+
+
 def send_goodbye_email(email: str) -> bool:
     """Send a goodbye/confirmation email after a user unsubscribes."""
     email_client = get_email_client()
@@ -335,7 +491,7 @@ def send_goodbye_email(email: str) -> bool:
                 <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='max-width:620px;'>
                     <tr>
                         <td style="background:linear-gradient(135deg,#19433c 0%,#286c61 100%);color:#ffffff;border-radius:14px;padding:40px 36px 42px 36px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
-                            <h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>🗺️ Fabric GPS</h1>
+                            <h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>Fabric GPS</h1>
                             <p style='margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);'>You have been unsubscribed from weekly updates.</p>
                         </td>
                     </tr>
@@ -841,7 +997,7 @@ def api_subscribe():
             return jsonify({"message": "Email is already subscribed and verified"}), 200
         
         # Send verification email (async by default)
-        email_queued = send_verification_email(email, verification_token)
+        email_queued = send_verification_email(email, verification_token, cadence=cadence)
         if email_queued:
             if ASYNC_EMAIL_VERIFICATION:
                 return jsonify({
@@ -863,6 +1019,36 @@ def api_subscribe():
     except Exception as e:
         otelLogger.error(f"Error creating subscription: {e}")
         return jsonify({"error": "Failed to create subscription"}), 500
+
+
+@app.route("/api/send-preferences-link", methods=["POST"])
+def api_send_preferences_link():
+    """Send an email with a link to manage subscription preferences.
+
+    Always returns 200 to prevent email enumeration.
+    """
+    data = request.get_json()
+    if not data or 'email' not in data:
+        return jsonify({"error": "Email is required"}), 400
+
+    email = data['email'].strip().lower()
+    if not email or '@' not in email:
+        return jsonify({"error": "Valid email is required"}), 400
+
+    # Always return the same message regardless of whether the email exists
+    generic_message = "If this email has an active subscription, a preferences link has been sent. Check your inbox (and spam folder)."
+
+    try:
+        engine = get_engine()
+        sub = get_verified_subscription_by_email(engine, email)
+        if sub:
+            preferences_url = f"{EMAIL_BASE_URL}/preferences?token={sub.unsubscribe_token}"
+            send_preferences_link_email(email, preferences_url)
+    except Exception as e:
+        otelLogger.error(f"Error processing preferences link request: {e}")
+
+    return jsonify({"message": generic_message}), 200
+
 
 @app.route("/api/verify-email", methods=["GET"])
 def api_verify_email():
@@ -907,8 +1093,32 @@ def verify_email_page():
             otelLogger.error(f"Error verifying email: {e}")
             return render_template('verify_email.html', error="Failed to verify email", pending=False), 500
 
-    # GET -> show pending confirmation UI
-    return render_template('verify_email.html', pending=True, token=token)
+    # GET -> look up cadence and watch context for display
+    cadence = 'weekly'
+    watch_feature_name = None
+    try:
+        engine = get_engine()
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy import select as sa_select
+        SessionLocal = sessionmaker(bind=engine, future=True)
+        with SessionLocal() as session:
+            verification = session.scalar(
+                sa_select(EmailVerificationModel).where(EmailVerificationModel.token == token)
+            )
+            if verification:
+                sub = session.scalar(
+                    sa_select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == verification.email)
+                )
+                if sub:
+                    cadence = sub.email_cadence or 'weekly'
+                if verification.pending_watch_release_id:
+                    release = session.get(ReleaseItemModel, verification.pending_watch_release_id)
+                    if release:
+                        watch_feature_name = release.feature_name
+    except Exception:
+        pass
+    return render_template('verify_email.html', pending=True, token=token,
+                           cadence=cadence, watch_feature_name=watch_feature_name)
 
 
 @app.route("/unsubscribe", methods=["GET", "POST"])
@@ -960,6 +1170,10 @@ def preferences_page():
 def api_preferences():
     """Get or update subscription preferences."""
     token = request.values.get('token')
+    if not token and request.is_json:
+        json_data = request.get_json(silent=True)
+        if json_data:
+            token = json_data.get('token')
     if not token:
         return jsonify({"error": "Token is required"}), 400
 
@@ -1107,7 +1321,7 @@ def watch_feature_page(release_item_id):
                 engine, email, release_item_id
             )
 
-            send_verification_email(email, verification_token)
+            send_verification_email(email, verification_token, watch_feature_name=feature_name)
             return render_template('watch.html', release_item_id=release_item_id,
                                    feature_name=feature_name, product_name=product_name,
                                    success=True)
@@ -1318,3 +1532,261 @@ def inject_nav():
         {"label": "About", "url": "/about"},
     ]
     return {"nav_items": nav_items, "current_year": datetime.utcnow().year, "canonical_base": EMAIL_BASE_URL}
+
+
+# ---------------------------------------------------------------------------
+# Email preview (development only)
+# ---------------------------------------------------------------------------
+if os.getenv("CURRENT_ENVIRONMENT") == "development":
+
+    @app.get("/dev/email-preview")
+    def email_preview_index():
+        """Index page listing all email previews."""
+        html = """<!DOCTYPE html><html><head><title>Email Previews</title>
+        <style>body{font-family:Segoe UI,sans-serif;max-width:700px;margin:2rem auto;padding:0 1rem;}
+        a{color:#19433c;display:block;margin:.5rem 0;font-size:1.1rem;}</style></head><body>
+        <h1>📧 Email Previews</h1>
+        <h3>Digest Emails</h3>
+        <a href="/dev/email-preview/weekly-digest" target="_blank">Weekly Digest</a>
+        <a href="/dev/email-preview/daily-digest" target="_blank">Daily Digest</a>
+        <h3>Watch Alert</h3>
+        <a href="/dev/email-preview/watch-alert" target="_blank">Feature Watch Alert</a>
+        <h3>Verification Emails</h3>
+        <a href="/dev/email-preview/verify-weekly" target="_blank">Verify — Weekly Subscription</a>
+        <a href="/dev/email-preview/verify-daily" target="_blank">Verify — Daily Subscription</a>
+        <a href="/dev/email-preview/verify-watch" target="_blank">Verify — Feature Watch</a>
+        <h3>Account Emails</h3>
+        <a href="/dev/email-preview/preferences-link" target="_blank">Preferences Link</a>
+        </body></html>"""
+        return html
+
+    @app.get("/dev/email-preview/<email_type>")
+    def email_preview(email_type):
+        """Render a preview of an email type. Development only."""
+        from datetime import datetime, timedelta
+        import sys
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from weekly_email_job import WeeklyEmailSender
+
+        sample_changes = [
+            {
+                "release_item_id": "preview-001",
+                "feature_name": "Real-Time Intelligence in Power BI",
+                "product_name": "Power BI",
+                "release_type": "General availability",
+                "release_status": "Shipped",
+                "feature_description": "Bring real-time data streams into Power BI dashboards with automatic refresh and live alerting capabilities.",
+                "release_date": (datetime.utcnow() + timedelta(days=30)).strftime("%Y-%m-%d"),
+                "last_modified": datetime.utcnow().strftime("%Y-%m-%d"),
+                "active": True,
+            },
+            {
+                "release_item_id": "preview-002",
+                "feature_name": "Dataflow Gen2 Incremental Refresh",
+                "product_name": "Data Factory",
+                "release_type": "Public preview",
+                "release_status": "Coming soon",
+                "feature_description": "Configure incremental refresh policies for Dataflow Gen2 to process only new and changed data.",
+                "release_date": (datetime.utcnow() + timedelta(days=60)).strftime("%Y-%m-%d"),
+                "last_modified": (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d"),
+                "active": True,
+            },
+            {
+                "release_item_id": "preview-003",
+                "feature_name": "Lakehouse Shortcut Enhancements",
+                "product_name": "OneLake",
+                "release_type": "General availability",
+                "release_status": "Shipped",
+                "feature_description": "New shortcut types and improved metadata sync for OneLake Lakehouse.",
+                "release_date": datetime.utcnow().strftime("%Y-%m-%d"),
+                "last_modified": (datetime.utcnow() - timedelta(days=2)).strftime("%Y-%m-%d"),
+                "active": True,
+            },
+            {
+                "release_item_id": "preview-004",
+                "feature_name": "Legacy Workspace Migration Tool",
+                "product_name": "Power BI",
+                "release_type": "General availability",
+                "release_status": "Shipped",
+                "feature_description": "Automated migration tool for converting legacy workspaces to the new workspace experience.",
+                "release_date": (datetime.utcnow() - timedelta(days=10)).strftime("%Y-%m-%d"),
+                "last_modified": (datetime.utcnow() - timedelta(days=3)).strftime("%Y-%m-%d"),
+                "active": False,
+            },
+        ]
+
+        # Build a mock subscription
+        mock_sub = type("MockSub", (), {
+            "email": "preview@example.com",
+            "email_cadence": "weekly",
+            "product_filter": None,
+            "release_type_filter": None,
+            "release_status_filter": None,
+            "unsubscribe_token": "preview-unsub-token",
+        })()
+
+        # Create sender without Azure connection (we only need HTML generation)
+        sender = object.__new__(WeeklyEmailSender)
+        sender.base_url = EMAIL_BASE_URL or "http://localhost:8000"
+
+        sample_ai_summary = (
+            "This week saw significant movement across Power BI and OneLake. "
+            "Real-Time Intelligence reached general availability in Power BI, "
+            "while Data Factory introduced incremental refresh for Dataflow Gen2 in public preview. "
+            "The Legacy Workspace Migration Tool was removed from the roadmap."
+        )
+
+        if email_type == "weekly-digest":
+            mock_sub.email_cadence = "weekly"
+            html = sender.generate_email_html(sample_changes, mock_sub, ai_summary=sample_ai_summary, cadence_label="Weekly")
+        elif email_type == "daily-digest":
+            mock_sub.email_cadence = "daily"
+            html = sender.generate_email_html(sample_changes[:2], mock_sub, ai_summary=None, cadence_label="Daily")
+        elif email_type == "watch-alert":
+            watch_changes = [
+                {
+                    "release_item_id": "preview-001",
+                    "feature_name": "Real-Time Intelligence in Power BI",
+                    "product_name": "Power BI",
+                    "release_type": "General availability",
+                    "release_status": "Shipped",
+                    "last_modified": datetime.utcnow().strftime("%Y-%m-%d"),
+                    "active": True,
+                },
+                {
+                    "release_item_id": "preview-004",
+                    "feature_name": "Legacy Workspace Migration Tool",
+                    "product_name": "Power BI",
+                    "release_type": "General availability",
+                    "release_status": "Shipped",
+                    "last_modified": datetime.utcnow().strftime("%Y-%m-%d"),
+                    "active": False,
+                },
+            ]
+            html = sender.send_watch_alert_email.__func__  # we need the HTML directly
+            # Generate watch HTML inline (reuse the method's HTML generation logic)
+            unsubscribe_url = f"{sender.base_url}/unsubscribe?token=preview-unsub-token"
+            preferences_url = f"{sender.base_url}/preferences?token=preview-unsub-token"
+            BODY_BG = "#f3f2f1"
+            CARD_BG = "#ffffff"
+            CARD_BORDER = "#e1e5e9"
+            CARD_SHADOW = "0 1px 2px rgba(0,0,0,0.04),0 4px 10px rgba(0,0,0,0.06)"
+            TEXT_SECONDARY = "#605e5c"
+            HERO_GRADIENT = "linear-gradient(135deg,#19433c 0%,#286c61 100%)"
+            items_html = ""
+            for w in watch_changes:
+                release_url = f"{sender.base_url}/release/{w['release_item_id']}"
+                removed_badge = ' <span style="background:#d13438;color:#fff;padding:2px 8px;border-radius:4px;font-size:11px;">REMOVED</span>' if w.get('active') is False else ''
+                items_html += f"""<div style="background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px;padding:18px 20px;margin-bottom:12px;box-shadow:{CARD_SHADOW};">
+  <div style="font-weight:600;font-size:15px;color:#323130;margin-bottom:6px;">
+    <a href="{release_url}" style="color:#19433c;text-decoration:none;">{w.get('feature_name', 'Unknown')}</a>{removed_badge}
+  </div>
+  <div style="font-size:13px;color:{TEXT_SECONDARY};">{w.get('product_name', '')} · {w.get('release_type', '')} · {w.get('release_status', '')}</div>
+  <div style="font-size:12px;color:{TEXT_SECONDARY};margin-top:4px;">Last modified: {w.get('last_modified', 'Unknown')}</div>
+</div>"""
+            html = f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Fabric GPS Watch Alert</title>
+<style>body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,sans-serif; }}</style>
+</head><body style="margin:0;padding:0;background:{BODY_BG};">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:{BODY_BG};padding:24px 0;">
+  <tr><td align="center" style="padding:0 12px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:640px;">
+      <tr><td style="background:{HERO_GRADIENT};color:#ffffff;border-radius:14px;padding:30px 34px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
+        <h1 style="margin:0 0 8px 0;font-size:24px;font-weight:600;">Fabric GPS</h1>
+        <p style="margin:0 0 4px 0;font-size:16px;font-weight:600;">Feature Watch Alert</p>
+        <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.9);">Features you're watching have been updated.</p>
+      </td></tr>
+      <tr><td style="height:24px;"></td></tr>
+      <tr><td style="padding:0;">{items_html}</td></tr>
+      <tr><td style="height:12px;"></td></tr>
+      <tr><td style="background:#f8f9fa;border:1px solid {CARD_BORDER};border-radius:10px;padding:18px 20px;text-align:center;font-size:12px;color:{TEXT_SECONDARY};line-height:1.5;">
+        <p style="margin:0 0 6px 0;">Sent to preview@example.com</p>
+        <p style="margin:0 0 6px 0;">
+          <a href="{preferences_url}" style="color:#19433c;text-decoration:none;font-weight:500;">Manage Watches</a>&nbsp;|&nbsp;
+          <a href="{unsubscribe_url}" style="color:#19433c;text-decoration:none;font-weight:500;">Unsubscribe</a>
+        </p>
+      </td></tr>
+      <tr><td style="height:30px;"></td></tr>
+    </table>
+  </td></tr>
+</table></body></html>"""
+        elif email_type in ("verify-weekly", "verify-daily", "verify-watch"):
+            # Build verification email HTML using the same function logic
+            base = EMAIL_BASE_URL or "http://localhost:8000"
+            verification_url = f"{base}/verify-email?token=preview-token"
+            cadence = "daily" if email_type == "verify-daily" else "weekly"
+            watch_name = "Real-Time Intelligence in Power BI" if email_type == "verify-watch" else None
+            is_watch = bool(watch_name)
+            if is_watch:
+                preheader = f"Verify your email to start watching {watch_name}."
+                hero_text = "Verify your email to start watching a feature on the Microsoft Fabric roadmap."
+                heading = "Start Watching a Feature"
+                body_text = (f"You requested to watch <strong>{watch_name}</strong> on the Fabric roadmap. "
+                             f"Click the button below to confirm your email and start receiving alerts when this feature changes.")
+                after_text = "After verifying, you&rsquo;ll be notified whenever this feature is updated on the roadmap."
+            else:
+                cadence_desc = "daily updates" if cadence == "daily" else "weekly updates every Monday"
+                preheader = f"Confirm your email to start {cadence_desc}."
+                hero_text = f"Verify your email to begin receiving {cadence_desc} about Microsoft Fabric roadmap changes."
+                heading = "Confirm Your Subscription"
+                body_text = f"Thanks for signing up! One quick step: click the button below to confirm this address and activate {cadence_desc}."
+                after_text = f"After verifying, you&rsquo;ll receive {cadence_desc} with the latest Microsoft Fabric roadmap changes. No spam &mdash; unsubscribe anytime."
+            html = f"""<!DOCTYPE html><html lang='en'><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1'>
+<title>Verify Your Email - Fabric GPS</title>
+<style>body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,sans-serif; }}</style>
+</head><body style='margin:0;padding:0;background:#f3f2f1;'>
+<span style="display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;color:transparent;">{preheader}</span>
+<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='background:#f3f2f1;padding:28px 0;'>
+<tr><td align='center' style='padding:0 14px;'>
+<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='max-width:620px;'>
+<tr><td style="background:linear-gradient(135deg,#19433c 0%,#286c61 100%);color:#ffffff;border-radius:14px;padding:40px 36px 42px 36px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
+<h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>Fabric GPS</h1>
+<p style='margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);'>{hero_text}</p>
+</td></tr><tr><td style='height:30px;'></td></tr><tr>
+<td style='background:#ffffff;border:1px solid #e1e5e9;border-radius:12px;padding:34px 32px;box-shadow:0 1px 2px rgba(0,0,0,0.04),0 4px 10px rgba(0,0,0,0.06);'>
+<h2 style='margin:0 0 18px 0;font-size:22px;line-height:1.25;color:#323130;font-weight:600;text-align:center;'>{heading}</h2>
+<p style='margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#605e5c;text-align:center;'>{body_text}</p>
+<div style='text-align:center;margin:10px 0 34px 0;'>
+<a href='{verification_url}' style="background:#19433c;background-image:linear-gradient(90deg,#19433c,#286c61);color:#ffffff;text-decoration:none;padding:14px 26px;font-size:15px;font-weight:600;border-radius:8px;display:inline-block;box-shadow:0 2px 4px rgba(0,0,0,0.18);">Verify Email</a>
+</div>
+<div style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:16px 18px;'>
+<p style='margin:0;font-size:13px;line-height:1.5;color:#605e5c;'>{after_text}</p>
+</div></td></tr><tr><td style='height:26px;'></td></tr><tr>
+<td style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:20px 22px;text-align:center;font-size:12px;line-height:1.55;color:#605e5c;'>
+<p style='margin:0 0 6px 0;'>This verification link expires in 24 hours.</p>
+<p style='margin:0 0 6px 0;'>If you didn't request this, ignore the message and you won't be subscribed.</p>
+<p style='margin:10px 0 0 0;color:#8a8886;'>&copy; Fabric GPS</p>
+</td></tr><tr><td style='height:34px;'></td></tr></table></td></tr></table></body></html>"""
+        elif email_type == "preferences-link":
+            base = EMAIL_BASE_URL or "http://localhost:8000"
+            preferences_url = f"{base}/preferences?token=preview-token"
+            html = f"""<!DOCTYPE html><html lang='en'><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1'>
+<title>Manage Your Subscription - Fabric GPS</title>
+<style>body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,sans-serif; }}</style>
+</head><body style='margin:0;padding:0;background:#f3f2f1;'>
+<span style="display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;color:transparent;">Your Fabric GPS preferences link is inside.</span>
+<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='background:#f3f2f1;padding:28px 0;'>
+<tr><td align='center' style='padding:0 14px;'>
+<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='max-width:620px;'>
+<tr><td style="background:linear-gradient(135deg,#19433c 0%,#286c61 100%);color:#ffffff;border-radius:14px;padding:40px 36px 42px 36px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
+<h1 style='margin:0 0 12px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;'>Fabric GPS</h1>
+<p style='margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);'>Manage your subscription preferences</p>
+</td></tr><tr><td style='height:30px;'></td></tr><tr>
+<td style='background:#ffffff;border:1px solid #e1e5e9;border-radius:12px;padding:34px 32px;box-shadow:0 1px 2px rgba(0,0,0,0.04),0 4px 10px rgba(0,0,0,0.06);'>
+<h2 style='margin:0 0 18px 0;font-size:22px;line-height:1.25;color:#323130;font-weight:600;text-align:center;'>Your Preferences Link</h2>
+<p style='margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#605e5c;text-align:center;'>Click the button below to manage your Fabric GPS subscription &mdash; update your email cadence, filters, and feature watches.</p>
+<div style='text-align:center;margin:10px 0 34px 0;'>
+<a href='{preferences_url}' style="background:#19433c;background-image:linear-gradient(90deg,#19433c,#286c61);color:#ffffff;text-decoration:none;padding:14px 26px;font-size:15px;font-weight:600;border-radius:8px;display:inline-block;box-shadow:0 2px 4px rgba(0,0,0,0.18);">Manage Preferences</a>
+</div>
+<div style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:16px 18px;'>
+<p style='margin:0;font-size:13px;line-height:1.5;color:#605e5c;'>Keep this link private &mdash; anyone with it can change your subscription settings.</p>
+</div></td></tr><tr><td style='height:26px;'></td></tr><tr>
+<td style='background:#f8f9fa;border:1px solid #e1e5e9;border-radius:10px;padding:20px 22px;text-align:center;font-size:12px;line-height:1.55;color:#605e5c;'>
+<p style='margin:0 0 6px 0;'>If you didn't request this, you can safely ignore this email.</p>
+<p style='margin:10px 0 0 0;color:#8a8886;'>&copy; Fabric GPS</p>
+</td></tr><tr><td style='height:34px;'></td></tr></table></td></tr></table></body></html>"""
+        else:
+            return "Unknown email type", 404
+
+        return html

--- a/server.py
+++ b/server.py
@@ -39,6 +39,7 @@ from db.db_sqlserver import (
     get_changelog_with_changes,
     get_subscription_by_unsubscribe_token, update_subscription_preferences,
     add_feature_watch, remove_feature_watch, get_feature_watches_for_subscription,
+    create_watch_verification,
 )
 from lib.embeddings import get_embedding, is_available as embeddings_available
 
@@ -1102,21 +1103,14 @@ def watch_feature_page(release_item_id):
                                    error="Please enter a valid email address.")
 
         try:
-            subscription_id, verification_token = create_email_subscription(
-                engine, email, pending_watch_release_id=release_item_id
+            _sub_id, verification_token = create_watch_verification(
+                engine, email, release_item_id
             )
 
-            if not verification_token:
-                # Already verified — watch was added immediately
-                return render_template('watch.html', release_item_id=release_item_id,
-                                       feature_name=feature_name, product_name=product_name,
-                                       success=True, already_verified=True)
-
-            # New or unverified — send verification email
             send_verification_email(email, verification_token)
             return render_template('watch.html', release_item_id=release_item_id,
                                    feature_name=feature_name, product_name=product_name,
-                                   success=True, already_verified=False)
+                                   success=True)
         except Exception as e:
             otelLogger.error(f"Error creating watch subscription: {e}")
             return render_template('watch.html', release_item_id=release_item_id,

--- a/server.py
+++ b/server.py
@@ -37,6 +37,8 @@ from db.db_sqlserver import (
     healthcheck as db_healthcheck,
     VALID_SORT_OPTIONS,
     get_changelog_with_changes,
+    get_subscription_by_unsubscribe_token, update_subscription_preferences,
+    add_feature_watch, remove_feature_watch, get_feature_watches_for_subscription,
 )
 from lib.embeddings import get_embedding, is_available as embeddings_available
 
@@ -96,7 +98,7 @@ REDIRECT_HOSTS = {h.strip() for h in os.getenv('REDIRECT_HOSTS', '').split(',') 
 # Use canonical host for email URLs if configured, otherwise fall back to BASE_URL
 EMAIL_BASE_URL = f"https://{CANONICAL_HOST}" if CANONICAL_HOST else BASE_URL
 
-_NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/api/subscribe", "/api/verify-email")
+_NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/preferences", "/api/subscribe", "/api/verify-email", "/api/preferences", "/api/watch")
 
 
 @app.after_request
@@ -825,10 +827,14 @@ def api_subscribe():
         filters['types'] = ','.join(data['types']) if isinstance(data['types'], list) else data['types']
     if 'statuses' in data and data['statuses']:
         filters['statuses'] = ','.join(data['statuses']) if isinstance(data['statuses'], list) else data['statuses']
+
+    cadence = data.get('cadence', 'weekly')
+    if cadence not in ('daily', 'weekly'):
+        cadence = 'weekly'
     
     try:
         engine = get_engine()
-        subscription_id, verification_token = create_email_subscription(engine, email, filters)
+        subscription_id, verification_token = create_email_subscription(engine, email, filters, cadence=cadence)
         
         if not verification_token:
             return jsonify({"message": "Email is already subscribed and verified"}), 200
@@ -931,6 +937,118 @@ def unsubscribe_page():
 
     # GET -> show pending confirmation UI
     return render_template('unsubscribe.html', pending=True, token=token)
+
+
+@app.route("/preferences", methods=["GET"])
+def preferences_page():
+    """HTML page for managing subscription preferences."""
+    token = request.args.get('token')
+    if not token:
+        return render_template('preferences.html', error="Missing preferences token"), 400
+
+    engine = get_engine()
+    sub = get_subscription_by_unsubscribe_token(engine, token)
+    if not sub:
+        return render_template('preferences.html', error="Invalid or expired token"), 404
+
+    watches = get_feature_watches_for_subscription(engine, sub.id)
+    return render_template('preferences.html', subscription=sub, watches=watches, token=token)
+
+
+@app.route("/api/preferences", methods=["GET", "POST"])
+def api_preferences():
+    """Get or update subscription preferences."""
+    token = request.values.get('token')
+    if not token:
+        return jsonify({"error": "Token is required"}), 400
+
+    engine = get_engine()
+
+    if request.method == 'GET':
+        sub = get_subscription_by_unsubscribe_token(engine, token)
+        if not sub:
+            return jsonify({"error": "Invalid token"}), 404
+        watches = get_feature_watches_for_subscription(engine, sub.id)
+        return jsonify({
+            "email": sub.email,
+            "cadence": sub.email_cadence,
+            "product_filter": sub.product_filter or '',
+            "release_type_filter": sub.release_type_filter or '',
+            "release_status_filter": sub.release_status_filter or '',
+            "watches": watches,
+        })
+
+    # POST — update preferences
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    preferences = {}
+    if 'cadence' in data:
+        cadence = data['cadence']
+        if cadence not in ('daily', 'weekly'):
+            return jsonify({"error": "cadence must be 'daily' or 'weekly'"}), 400
+        preferences['email_cadence'] = cadence
+    if 'products' in data:
+        preferences['product_filter'] = ','.join(data['products']) if isinstance(data['products'], list) else data['products']
+    if 'types' in data:
+        preferences['release_type_filter'] = ','.join(data['types']) if isinstance(data['types'], list) else data['types']
+    if 'statuses' in data:
+        preferences['release_status_filter'] = ','.join(data['statuses']) if isinstance(data['statuses'], list) else data['statuses']
+
+    if not preferences:
+        return jsonify({"error": "No valid preferences provided"}), 400
+
+    success = update_subscription_preferences(engine, token, preferences)
+    if success:
+        return jsonify({"message": "Preferences updated"})
+    return jsonify({"error": "Invalid token"}), 404
+
+
+@app.route("/api/watch", methods=["POST"])
+def api_add_watch():
+    """Add a feature watch for a subscriber."""
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    token = data.get('token')
+    release_item_id = data.get('release_item_id')
+    if not token or not release_item_id:
+        return jsonify({"error": "token and release_item_id are required"}), 400
+
+    engine = get_engine()
+    sub = get_subscription_by_unsubscribe_token(engine, token)
+    if not sub:
+        return jsonify({"error": "Invalid token"}), 404
+
+    created = add_feature_watch(engine, sub.id, release_item_id)
+    if created:
+        return jsonify({"message": "Watch added"}), 201
+    return jsonify({"message": "Already watching this feature"})
+
+
+@app.route("/api/watch", methods=["DELETE"])
+def api_remove_watch():
+    """Remove a feature watch for a subscriber."""
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    token = data.get('token')
+    release_item_id = data.get('release_item_id')
+    if not token or not release_item_id:
+        return jsonify({"error": "token and release_item_id are required"}), 400
+
+    engine = get_engine()
+    sub = get_subscription_by_unsubscribe_token(engine, token)
+    if not sub:
+        return jsonify({"error": "Invalid token"}), 404
+
+    removed = remove_feature_watch(engine, sub.id, release_item_id)
+    if removed:
+        return jsonify({"message": "Watch removed"})
+    return jsonify({"error": "Watch not found"}), 404
 
 
 @app.get("/api/releases/history/<release_item_id>")
@@ -1071,8 +1189,11 @@ def robots_txt():
 Allow: /
 Disallow: /verify-email
 Disallow: /unsubscribe
+Disallow: /preferences
 Disallow: /api/subscribe
 Disallow: /api/verify-email
+Disallow: /api/preferences
+Disallow: /api/watch
 Disallow: /healthcheck
 Disallow: /webhooks/
 

--- a/server.py
+++ b/server.py
@@ -1664,7 +1664,6 @@ if os.getenv("CURRENT_ENVIRONMENT") == "development":
                     "active": False,
                 },
             ]
-            html = sender.send_watch_alert_email.__func__  # we need the HTML directly
             # Generate watch HTML inline (reuse the method's HTML generation logic)
             unsubscribe_url = f"{sender.base_url}/unsubscribe?token=preview-unsub-token"
             preferences_url = f"{sender.base_url}/preferences?token=preview-unsub-token"

--- a/server.py
+++ b/server.py
@@ -184,12 +184,13 @@ def send_verification_email(email: str, verification_token: str,
         # Build context-aware copy
         is_watch = bool(watch_feature_name)
         if is_watch:
-            preheader = f"Verify your email to start watching {watch_feature_name}."
+            escaped_watch_feature_name = escape(watch_feature_name)
+            preheader = f"Verify your email to start watching {escaped_watch_feature_name}."
             hero_text = "Verify your email to start watching a feature on the Microsoft Fabric roadmap."
             subject = f"Verify your email to watch {watch_feature_name} — Fabric GPS"
             heading = "Start Watching a Feature"
             body_text = (
-                f"You requested to watch <strong>{watch_feature_name}</strong> on the Fabric roadmap. "
+                f"You requested to watch <strong>{escaped_watch_feature_name}</strong> on the Fabric roadmap. "
                 f"Click the button below to confirm your email and start receiving alerts when this feature changes."
             )
             after_text = "After verifying, you&rsquo;ll be notified whenever this feature is updated on the roadmap."

--- a/server.py
+++ b/server.py
@@ -40,7 +40,7 @@ from db.db_sqlserver import (
     get_subscription_by_unsubscribe_token, update_subscription_preferences,
     get_verified_subscription_by_email,
     add_feature_watch, remove_feature_watch, get_feature_watches_for_subscription,
-    create_watch_verification,
+    create_watch_verification, get_release_item_by_id,
 )
 from lib.embeddings import get_embedding, is_available as embeddings_available
 
@@ -1237,6 +1237,9 @@ def api_add_watch():
     sub = get_subscription_by_unsubscribe_token(engine, token)
     if not sub:
         return jsonify({"error": "Invalid token"}), 404
+
+    if not get_release_item_by_id(engine, release_item_id):
+        return jsonify({"error": "Release item not found"}), 404
 
     created = add_feature_watch(engine, sub.id, release_item_id)
     if created:

--- a/server.py
+++ b/server.py
@@ -98,7 +98,7 @@ REDIRECT_HOSTS = {h.strip() for h in os.getenv('REDIRECT_HOSTS', '').split(',') 
 # Use canonical host for email URLs if configured, otherwise fall back to BASE_URL
 EMAIL_BASE_URL = f"https://{CANONICAL_HOST}" if CANONICAL_HOST else BASE_URL
 
-_NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/preferences", "/api/subscribe", "/api/verify-email", "/api/preferences", "/api/watch")
+_NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/preferences", "/watch/", "/api/subscribe", "/api/verify-email", "/api/preferences", "/api/watch")
 
 
 @app.after_request
@@ -1080,6 +1080,51 @@ def release_detail(release_item_id):
             return render_template('release.html', release=None, history=None), 404
         history = fetch_history_rows(engine, release_item_id)
         return render_template('release.html', release=row, history=history)
+
+
+@app.route("/watch/<release_item_id>", methods=["GET", "POST"])
+def watch_feature_page(release_item_id):
+    """Page to subscribe to watch alerts for a specific release item."""
+    engine = get_engine()
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    with SessionLocal() as session:
+        release = session.get(ReleaseItemModel, release_item_id)
+        if not release:
+            return render_template('watch.html', release=None, error="Release not found"), 404
+        feature_name = release.feature_name
+        product_name = release.product_name
+
+    if request.method == 'POST':
+        email = (request.form.get('email') or '').strip().lower()
+        if not email or '@' not in email:
+            return render_template('watch.html', release_item_id=release_item_id,
+                                   feature_name=feature_name, product_name=product_name,
+                                   error="Please enter a valid email address.")
+
+        try:
+            subscription_id, verification_token = create_email_subscription(
+                engine, email, pending_watch_release_id=release_item_id
+            )
+
+            if not verification_token:
+                # Already verified — watch was added immediately
+                return render_template('watch.html', release_item_id=release_item_id,
+                                       feature_name=feature_name, product_name=product_name,
+                                       success=True, already_verified=True)
+
+            # New or unverified — send verification email
+            send_verification_email(email, verification_token)
+            return render_template('watch.html', release_item_id=release_item_id,
+                                   feature_name=feature_name, product_name=product_name,
+                                   success=True, already_verified=False)
+        except Exception as e:
+            otelLogger.error(f"Error creating watch subscription: {e}")
+            return render_template('watch.html', release_item_id=release_item_id,
+                                   feature_name=feature_name, product_name=product_name,
+                                   error="Something went wrong. Please try again.")
+
+    return render_template('watch.html', release_item_id=release_item_id,
+                           feature_name=feature_name, product_name=product_name)
 
 
 @app.get("/changelog")

--- a/static/styles.css
+++ b/static/styles.css
@@ -700,6 +700,142 @@ body {
   color: rgba(255, 255, 255, 0.9);
 }
 
+/* Form components */
+.form-input {
+  width: 100%;
+  padding: var(--spacing-s) var(--spacing-m);
+  border: 1px solid var(--fabric-neutral-grey-30);
+  border-radius: 6px;
+  font-family: var(--font-family-primary);
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+  background: white;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--fabric-primary);
+  box-shadow: 0 0 0 2px rgba(25, 67, 60, 0.1);
+}
+
+.form-group {
+  margin-bottom: var(--spacing-m);
+}
+
+.form-group label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: var(--spacing-s);
+  font-size: var(--font-size-body);
+  color: var(--fabric-neutral-grey-160);
+}
+
+.form-group select {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--fabric-neutral-grey-30);
+  border-radius: 6px;
+  font-size: var(--font-size-body);
+  background: white;
+  min-height: 70px;
+}
+
+.radio-group {
+  display: flex;
+  gap: var(--spacing-l);
+  margin: var(--spacing-m) 0;
+}
+
+.radio-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  cursor: pointer;
+  font-size: var(--font-size-body);
+}
+
+.radio-label input {
+  accent-color: var(--fabric-primary);
+}
+
+/* Centered page card (for single-column action pages) */
+.page-card {
+  max-width: 600px;
+  margin: var(--spacing-xl) auto;
+  background: white;
+  border-radius: 12px;
+  padding: var(--spacing-xl);
+  box-shadow: var(--elevation-2);
+  border: 1px solid var(--fabric-neutral-grey-30);
+}
+
+.page-card-wide {
+  max-width: 700px;
+  margin: var(--spacing-xl) auto;
+  background: white;
+  border-radius: 12px;
+  padding: var(--spacing-xl);
+  box-shadow: var(--elevation-2);
+  border: 1px solid var(--fabric-neutral-grey-30);
+}
+
+.status-icon {
+  font-size: 3.5rem;
+  margin-bottom: var(--spacing-m);
+  line-height: 1;
+}
+
+/* Watch/list items */
+.watch-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.watch-list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-m);
+  border: 1px solid var(--fabric-neutral-grey-30);
+  border-radius: 8px;
+  margin-bottom: var(--spacing-s);
+}
+
+.watch-list-item a {
+  font-weight: 600;
+  color: var(--fabric-primary);
+  text-decoration: none;
+}
+
+.watch-list-item a:hover {
+  text-decoration: underline;
+}
+
+.btn-remove {
+  background: none;
+  border: 1px solid var(--fabric-semantic-error);
+  color: var(--fabric-semantic-error);
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.btn-remove:hover {
+  background: var(--fabric-semantic-error);
+  color: white;
+}
+
+@media (max-width: 768px) {
+  .page-card, .page-card-wide {
+    margin: var(--spacing-m);
+    padding: var(--spacing-l);
+  }
+}
+
 /* Focus indicators */
 .button:focus-visible,
 a:focus-visible {

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -3,104 +3,94 @@
 {% block extra_head %}
 <meta name="robots" content="noindex, nofollow">
 <style>
-    .preferences-container { max-width: 700px; margin: 2rem auto; padding: var(--spacing-xl); background: white; border-radius: 12px; box-shadow: var(--elevation-2); }
-    .pref-section { margin-bottom: var(--spacing-xl); }
-    .pref-section h2 { font-size: 1.1rem; margin-bottom: var(--spacing-m); color: var(--fabric-neutral-grey-130); }
-    .pref-field { margin-bottom: var(--spacing-l); }
-    .pref-field label { display: block; font-weight: 600; margin-bottom: var(--spacing-s); color: var(--fabric-neutral-grey-110); }
-    .pref-field select, .pref-field input[type="text"] { width: 100%; padding: 8px 12px; border: 1px solid var(--fabric-neutral-grey-40); border-radius: 6px; font-size: .9rem; }
-    .cadence-options { display: flex; gap: var(--spacing-l); }
-    .cadence-option { display: flex; align-items: center; gap: var(--spacing-s); cursor: pointer; }
-    .cadence-option input[type="radio"] { accent-color: var(--color-primary); }
-    .watches-list { list-style: none; padding: 0; margin: 0; }
-    .watch-item { display: flex; justify-content: space-between; align-items: center; padding: var(--spacing-m); border: 1px solid var(--fabric-neutral-grey-30); border-radius: 8px; margin-bottom: var(--spacing-s); }
-    .watch-item-info { flex: 1; }
-    .watch-item-name { font-weight: 600; color: var(--fabric-neutral-grey-130); }
-    .watch-item-product { font-size: .85rem; color: var(--fabric-neutral-grey-90); }
-    .btn-remove { background: none; border: 1px solid var(--fabric-semantic-error); color: var(--fabric-semantic-error); padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: .85rem; }
-    .btn-remove:hover { background: var(--fabric-semantic-error); color: white; }
-    .multi-select { min-height: 80px; }
-    .save-bar { display: flex; justify-content: flex-end; gap: var(--spacing-m); margin-top: var(--spacing-xl); padding-top: var(--spacing-l); border-top: 1px solid var(--fabric-neutral-grey-30); }
-    .success-icon, .error-icon { font-size: 4rem; margin-bottom: var(--spacing-l); text-align: center; }
-    .success-message { color: var(--fabric-semantic-success); text-align: center; }
-    .error-message { color: var(--fabric-semantic-error); text-align: center; }
-    #save-message { margin-top: var(--spacing-m); text-align: right; font-size: .85rem; }
+.save-bar {
+    display: flex;
+    gap: var(--spacing-m);
+    justify-content: flex-end;
+    margin-top: var(--spacing-l);
+    padding-top: var(--spacing-l);
+    border-top: 1px solid var(--fabric-neutral-grey-30);
+}
+.empty-watches {
+    color: var(--fabric-neutral-grey-90);
+    font-style: italic;
+    text-align: center;
+    padding: var(--spacing-l) 0;
+}
 </style>
 {% endblock %}
-
+{% block herotitle %}Email Preferences{% endblock %}
+{% block herosubtitle %}Customize your Fabric GPS email notifications.{% endblock %}
 {% block content %}
-<div class="preferences-container">
+<div class="container">
+    <div class="page-card-wide">
     {% if error %}
-        <div class="error-icon">❌</div>
-        <h1 class="error-message">{{ error }}</h1>
-        <p style="text-align:center;">Please use the link from your email to access preferences.</p>
-        <div style="text-align:center; margin-top: var(--spacing-l);">
-            <a href="/" class="button button-primary">Back to Home</a>
+        <div style="text-align: center;">
+            <div class="status-icon">❌</div>
+            <h2 style="color: var(--fabric-semantic-error);">{{ error }}</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">Please use the link from your email to access preferences.</p>
+            <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
         </div>
     {% elif subscription %}
-        <h1 style="margin-top:0; font-size:1.4rem;">Email Preferences</h1>
-        <p style="color:var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-xl);">Managing preferences for <strong>{{ subscription.email }}</strong></p>
+        <h2 style="margin-top: 0; font-size: var(--font-size-subtitle);">Email Preferences</h2>
+        <p style="color: var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-xl);">Managing preferences for <strong>{{ subscription.email }}</strong></p>
 
-        <div class="pref-section">
-            <h2>📬 Email Frequency</h2>
-            <div class="cadence-options">
-                <label class="cadence-option">
-                    <input type="radio" name="cadence" value="daily" {{ 'checked' if subscription.email_cadence == 'daily' }}>
-                    Daily
+        <div style="margin-bottom: var(--spacing-xl);">
+            <h3 style="font-size: 1rem; margin-bottom: var(--spacing-s);">Email Frequency</h3>
+            <div class="radio-group">
+                <label class="radio-label">
+                    <input type="radio" name="cadence" value="weekly" {{ 'checked' if subscription.email_cadence == 'weekly' else '' }}> Weekly (Mondays)
                 </label>
-                <label class="cadence-option">
-                    <input type="radio" name="cadence" value="weekly" {{ 'checked' if subscription.email_cadence == 'weekly' }}>
-                    Weekly (Mondays)
+                <label class="radio-label">
+                    <input type="radio" name="cadence" value="daily" {{ 'checked' if subscription.email_cadence == 'daily' else '' }}> Daily
                 </label>
             </div>
         </div>
 
-        <div class="pref-section">
-            <h2>🔍 Content Filters</h2>
-            <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-m);">Leave empty to receive updates for all products, types, and statuses.</p>
-
-            <div class="pref-field">
+        <div style="margin-bottom: var(--spacing-xl);">
+            <h3 style="font-size: 1rem; margin-bottom: var(--spacing-m);">Filters (optional)</h3>
+            <div class="form-group">
                 <label for="product-select">Products</label>
-                <select id="product-select" class="multi-select" multiple></select>
+                <select id="product-select" multiple></select>
             </div>
-
-            <div class="pref-field">
+            <div class="form-group">
                 <label for="type-select">Release Types</label>
-                <select id="type-select" class="multi-select" multiple></select>
+                <select id="type-select" multiple></select>
             </div>
-
-            <div class="pref-field">
-                <label for="status-select">Release Statuses</label>
-                <select id="status-select" class="multi-select" multiple></select>
+            <div class="form-group">
+                <label for="status-select">Statuses</label>
+                <select id="status-select" multiple></select>
             </div>
         </div>
 
-        <div class="pref-section">
-            <h2>👁️ Feature Watches</h2>
-            <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-m);">Get alerted within an hour when these features change, regardless of your digest frequency.</p>
+        {% if watches is defined %}
+        <div style="margin-bottom: var(--spacing-xl);">
+            <h3 style="font-size: 1rem; margin-bottom: var(--spacing-m);">👁️ Feature Watches</h3>
             {% if watches %}
-            <ul class="watches-list" id="watches-list">
+            <ul class="watch-list" id="watches-list">
                 {% for w in watches %}
-                <li class="watch-item" data-release-id="{{ w.release_item_id }}">
-                    <div class="watch-item-info">
-                        <div class="watch-item-name"><a href="/release/{{ w.release_item_id }}">{{ w.feature_name }}</a></div>
-                        <div class="watch-item-product">{{ w.product_name }}</div>
+                <li class="watch-list-item" data-release-id="{{ w.release_item_id }}">
+                    <div>
+                        <div><a href="/release/{{ w.release_item_id }}">{{ w.feature_name }}</a></div>
+                        <div style="font-size: var(--font-size-caption); color: var(--fabric-neutral-grey-90);">{{ w.product_name }}</div>
                     </div>
                     <button class="btn-remove" onclick="removeWatch('{{ w.release_item_id }}')">Remove</button>
                 </li>
                 {% endfor %}
             </ul>
             {% else %}
-            <p style="color:var(--fabric-neutral-grey-90); font-style:italic;" id="no-watches-msg">No feature watches. Visit a release page to add one.</p>
+            <p class="empty-watches" id="no-watches-msg">No feature watches. Visit a release page to add one.</p>
             {% endif %}
         </div>
+        {% endif %}
 
         <div class="save-bar">
             <a href="/" class="button button-secondary">Cancel</a>
             <button class="button button-primary" id="save-btn" onclick="savePreferences()">Save Preferences</button>
         </div>
-        <div id="save-message"></div>
+        <div id="save-message" class="subscription-message" style="text-align: center;"></div>
     {% endif %}
+    </div>
 </div>
 {% endblock %}
 
@@ -160,14 +150,16 @@ async function savePreferences() {
         const result = await resp.json();
         if (resp.ok) {
             msg.textContent = '✅ Preferences saved!';
-            msg.style.color = 'var(--fabric-semantic-success)';
+            msg.className = 'subscription-message success';
         } else {
             msg.textContent = '❌ ' + (result.error || 'Failed to save');
-            msg.style.color = 'var(--fabric-semantic-error)';
+            msg.className = 'subscription-message error';
         }
+        msg.style.display = 'block';
     } catch(e) {
         msg.textContent = '❌ Network error';
-        msg.style.color = 'var(--fabric-semantic-error)';
+        msg.className = 'subscription-message error';
+        msg.style.display = 'block';
     }
     btn.disabled = false; btn.textContent = 'Save Preferences';
 }
@@ -176,25 +168,32 @@ async function removeWatch(releaseId) {
     try {
         const resp = await fetch('/api/watch', {
             method: 'DELETE',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ token: TOKEN, release_item_id: releaseId }),
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({token: TOKEN, release_item_id: releaseId}),
         });
         if (resp.ok) {
             const item = document.querySelector(`[data-release-id="${releaseId}"]`);
             if (item) item.remove();
-            if (!document.querySelector('.watch-item')) {
+            if (!document.querySelector('.watch-list-item')) {
                 const list = document.getElementById('watches-list');
                 if (list) list.remove();
-                const section = document.querySelector('.pref-section:last-of-type');
-                const msg = document.createElement('p');
-                msg.style.cssText = 'color:var(--fabric-neutral-grey-90); font-style:italic;';
-                msg.textContent = 'No feature watches. Visit a release page to add one.';
-                section.appendChild(msg);
+                const msg = document.getElementById('no-watches-msg');
+                if (msg) msg.style.display = 'block';
+                else {
+                    const container = document.querySelector('.watch-list')?.parentElement;
+                    if (container) {
+                        const p = document.createElement('p');
+                        p.className = 'empty-watches';
+                        p.id = 'no-watches-msg';
+                        p.textContent = 'No feature watches. Visit a release page to add one.';
+                        container.appendChild(p);
+                    }
+                }
             }
         }
     } catch(e) { console.error('Failed to remove watch', e); }
 }
 
-document.addEventListener('DOMContentLoaded', loadFilterOptions);
+document.addEventListener('DOMContentLoaded', () => { loadFilterOptions(); });
 </script>
 {% endblock %}

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -96,11 +96,11 @@
 
 {% block scripts %}
 <script>
-const TOKEN = '{{ token }}';
+const TOKEN = {{ token | tojson }};
 const CURRENT = {
-    products: '{{ subscription.product_filter or "" }}'.split(',').filter(Boolean),
-    types: '{{ subscription.release_type_filter or "" }}'.split(',').filter(Boolean),
-    statuses: '{{ subscription.release_status_filter or "" }}'.split(',').filter(Boolean),
+    products: {{ (subscription.product_filter or "") | tojson }}.split(',').filter(Boolean),
+    types: {{ (subscription.release_type_filter or "") | tojson }}.split(',').filter(Boolean),
+    statuses: {{ (subscription.release_status_filter or "") | tojson }}.split(',').filter(Boolean),
 };
 
 async function loadFilterOptions() {

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -1,0 +1,200 @@
+{% extends 'base.html' %}
+{% block title %}Manage Preferences — Fabric GPS{% endblock %}
+{% block extra_head %}
+<meta name="robots" content="noindex, nofollow">
+<style>
+    .preferences-container { max-width: 700px; margin: 2rem auto; padding: var(--spacing-xl); background: white; border-radius: 12px; box-shadow: var(--elevation-2); }
+    .pref-section { margin-bottom: var(--spacing-xl); }
+    .pref-section h2 { font-size: 1.1rem; margin-bottom: var(--spacing-m); color: var(--fabric-neutral-grey-130); }
+    .pref-field { margin-bottom: var(--spacing-l); }
+    .pref-field label { display: block; font-weight: 600; margin-bottom: var(--spacing-s); color: var(--fabric-neutral-grey-110); }
+    .pref-field select, .pref-field input[type="text"] { width: 100%; padding: 8px 12px; border: 1px solid var(--fabric-neutral-grey-40); border-radius: 6px; font-size: .9rem; }
+    .cadence-options { display: flex; gap: var(--spacing-l); }
+    .cadence-option { display: flex; align-items: center; gap: var(--spacing-s); cursor: pointer; }
+    .cadence-option input[type="radio"] { accent-color: var(--color-primary); }
+    .watches-list { list-style: none; padding: 0; margin: 0; }
+    .watch-item { display: flex; justify-content: space-between; align-items: center; padding: var(--spacing-m); border: 1px solid var(--fabric-neutral-grey-30); border-radius: 8px; margin-bottom: var(--spacing-s); }
+    .watch-item-info { flex: 1; }
+    .watch-item-name { font-weight: 600; color: var(--fabric-neutral-grey-130); }
+    .watch-item-product { font-size: .85rem; color: var(--fabric-neutral-grey-90); }
+    .btn-remove { background: none; border: 1px solid var(--fabric-semantic-error); color: var(--fabric-semantic-error); padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: .85rem; }
+    .btn-remove:hover { background: var(--fabric-semantic-error); color: white; }
+    .multi-select { min-height: 80px; }
+    .save-bar { display: flex; justify-content: flex-end; gap: var(--spacing-m); margin-top: var(--spacing-xl); padding-top: var(--spacing-l); border-top: 1px solid var(--fabric-neutral-grey-30); }
+    .success-icon, .error-icon { font-size: 4rem; margin-bottom: var(--spacing-l); text-align: center; }
+    .success-message { color: var(--fabric-semantic-success); text-align: center; }
+    .error-message { color: var(--fabric-semantic-error); text-align: center; }
+    #save-message { margin-top: var(--spacing-m); text-align: right; font-size: .85rem; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="preferences-container">
+    {% if error %}
+        <div class="error-icon">❌</div>
+        <h1 class="error-message">{{ error }}</h1>
+        <p style="text-align:center;">Please use the link from your email to access preferences.</p>
+        <div style="text-align:center; margin-top: var(--spacing-l);">
+            <a href="/" class="button button-primary">Back to Home</a>
+        </div>
+    {% elif subscription %}
+        <h1 style="margin-top:0; font-size:1.4rem;">Email Preferences</h1>
+        <p style="color:var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-xl);">Managing preferences for <strong>{{ subscription.email }}</strong></p>
+
+        <div class="pref-section">
+            <h2>📬 Email Frequency</h2>
+            <div class="cadence-options">
+                <label class="cadence-option">
+                    <input type="radio" name="cadence" value="daily" {{ 'checked' if subscription.email_cadence == 'daily' }}>
+                    Daily
+                </label>
+                <label class="cadence-option">
+                    <input type="radio" name="cadence" value="weekly" {{ 'checked' if subscription.email_cadence == 'weekly' }}>
+                    Weekly (Mondays)
+                </label>
+            </div>
+        </div>
+
+        <div class="pref-section">
+            <h2>🔍 Content Filters</h2>
+            <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-m);">Leave empty to receive updates for all products, types, and statuses.</p>
+
+            <div class="pref-field">
+                <label for="product-select">Products</label>
+                <select id="product-select" class="multi-select" multiple></select>
+            </div>
+
+            <div class="pref-field">
+                <label for="type-select">Release Types</label>
+                <select id="type-select" class="multi-select" multiple></select>
+            </div>
+
+            <div class="pref-field">
+                <label for="status-select">Release Statuses</label>
+                <select id="status-select" class="multi-select" multiple></select>
+            </div>
+        </div>
+
+        <div class="pref-section">
+            <h2>👁️ Feature Watches</h2>
+            <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-m);">Get alerted within an hour when these features change, regardless of your digest frequency.</p>
+            {% if watches %}
+            <ul class="watches-list" id="watches-list">
+                {% for w in watches %}
+                <li class="watch-item" data-release-id="{{ w.release_item_id }}">
+                    <div class="watch-item-info">
+                        <div class="watch-item-name"><a href="/release/{{ w.release_item_id }}">{{ w.feature_name }}</a></div>
+                        <div class="watch-item-product">{{ w.product_name }}</div>
+                    </div>
+                    <button class="btn-remove" onclick="removeWatch('{{ w.release_item_id }}')">Remove</button>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p style="color:var(--fabric-neutral-grey-90); font-style:italic;" id="no-watches-msg">No feature watches. Visit a release page to add one.</p>
+            {% endif %}
+        </div>
+
+        <div class="save-bar">
+            <a href="/" class="button button-secondary">Cancel</a>
+            <button class="button button-primary" id="save-btn" onclick="savePreferences()">Save Preferences</button>
+        </div>
+        <div id="save-message"></div>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const TOKEN = '{{ token }}';
+const CURRENT = {
+    products: '{{ subscription.product_filter or "" }}'.split(',').filter(Boolean),
+    types: '{{ subscription.release_type_filter or "" }}'.split(',').filter(Boolean),
+    statuses: '{{ subscription.release_status_filter or "" }}'.split(',').filter(Boolean),
+};
+
+async function loadFilterOptions() {
+    try {
+        const resp = await fetch('/api/filter-options');
+        const data = await resp.json();
+        populateSelect('product-select', data.product_names || [], CURRENT.products);
+        populateSelect('type-select', data.release_types || [], CURRENT.types);
+        populateSelect('status-select', data.release_statuses || [], CURRENT.statuses);
+    } catch(e) { console.error('Failed to load filter options', e); }
+}
+
+function populateSelect(id, options, selected) {
+    const sel = document.getElementById(id);
+    sel.innerHTML = '';
+    options.forEach(opt => {
+        const o = document.createElement('option');
+        o.value = opt; o.textContent = opt;
+        if (selected.includes(opt)) o.selected = true;
+        sel.appendChild(o);
+    });
+}
+
+function getSelected(id) {
+    return Array.from(document.getElementById(id).selectedOptions).map(o => o.value);
+}
+
+async function savePreferences() {
+    const btn = document.getElementById('save-btn');
+    const msg = document.getElementById('save-message');
+    btn.disabled = true; btn.textContent = 'Saving...';
+
+    const body = {
+        token: TOKEN,
+        cadence: document.querySelector('input[name="cadence"]:checked').value,
+        products: getSelected('product-select'),
+        types: getSelected('type-select'),
+        statuses: getSelected('status-select'),
+    };
+
+    try {
+        const resp = await fetch('/api/preferences', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const result = await resp.json();
+        if (resp.ok) {
+            msg.textContent = '✅ Preferences saved!';
+            msg.style.color = 'var(--fabric-semantic-success)';
+        } else {
+            msg.textContent = '❌ ' + (result.error || 'Failed to save');
+            msg.style.color = 'var(--fabric-semantic-error)';
+        }
+    } catch(e) {
+        msg.textContent = '❌ Network error';
+        msg.style.color = 'var(--fabric-semantic-error)';
+    }
+    btn.disabled = false; btn.textContent = 'Save Preferences';
+}
+
+async function removeWatch(releaseId) {
+    try {
+        const resp = await fetch('/api/watch', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token: TOKEN, release_item_id: releaseId }),
+        });
+        if (resp.ok) {
+            const item = document.querySelector(`[data-release-id="${releaseId}"]`);
+            if (item) item.remove();
+            if (!document.querySelector('.watch-item')) {
+                const list = document.getElementById('watches-list');
+                if (list) list.remove();
+                const section = document.querySelector('.pref-section:last-of-type');
+                const msg = document.createElement('p');
+                msg.style.cssText = 'color:var(--fabric-neutral-grey-90); font-style:italic;';
+                msg.textContent = 'No feature watches. Visit a release page to add one.';
+                section.appendChild(msg);
+            }
+        }
+    } catch(e) { console.error('Failed to remove watch', e); }
+}
+
+document.addEventListener('DOMContentLoaded', loadFilterOptions);
+</script>
+{% endblock %}

--- a/templates/release.html
+++ b/templates/release.html
@@ -85,6 +85,7 @@
             <div class="modal-actions-row" style="margin-top: var(--spacing-l);">
                 <span class="modal-action-buttons">
                     <a href="/" id="back-to-roadmap" class="button button-primary">← Back to Roadmap</a>
+                    <a href="/watch/{{ release.release_item_id }}" class="button button-secondary">👁️ Watch this Feature</a>
                     <button class="link-copy" id="copy-release-link">Copy Direct Link</button>
                     <a href="/api/releases?release_item_id={{ release.release_item_id }}" class="button button-secondary" target="_blank" rel="noopener">View API JSON</a>
                 </span>

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% block title %}Email Notifications — Fabric GPS | Weekly Microsoft Fabric Updates{% endblock %}
-{% block meta_description %}Subscribe to weekly Microsoft Fabric roadmap email summaries. Get concise Monday digests of new features, status changes, and release dates delivered to your inbox.{% endblock %}
-{% block og_title %}Email Notifications — Fabric GPS | Weekly Microsoft Fabric Updates{% endblock %}
-{% block og_description %}Subscribe to weekly Microsoft Fabric roadmap email summaries. Get concise Monday digests of new features, status changes, and release dates.{% endblock %}
-{% block twitter_title %}Email Notifications — Fabric GPS | Weekly Microsoft Fabric Updates{% endblock %}
-{% block twitter_description %}Subscribe to weekly Microsoft Fabric roadmap email summaries. Get concise Monday digests of new features, status changes, and release dates.{% endblock %}
+{% block meta_description %}Subscribe to Microsoft Fabric roadmap email summaries. Choose daily or weekly digests, filter by product, and watch specific features for instant alerts.{% endblock %}
+{% block og_title %}Email Notifications — Fabric GPS | Microsoft Fabric Updates{% endblock %}
+{% block og_description %}Subscribe to Microsoft Fabric roadmap email summaries. Choose daily or weekly digests, filter by product, and watch specific features.{% endblock %}
+{% block twitter_title %}Email Notifications — Fabric GPS | Microsoft Fabric Updates{% endblock %}
+{% block twitter_description %}Subscribe to Microsoft Fabric roadmap email summaries. Choose daily or weekly digests, filter by product, and watch specific features.{% endblock %}
 {% block extra_head %}
 <style>
 .subscription-section{max-width:600px;margin:0 auto;padding:var(--spacing-xl) 0;}
@@ -14,32 +14,66 @@
 .subscription-benefits li{margin-bottom:var(--spacing-s);color:var(--color-text-secondary);} 
 .email-input{flex:1;min-width:200px;} 
 .subscription-form{display:flex;gap:var(--spacing-m);margin:var(--spacing-l) 0;} 
+.cadence-row{display:flex;gap:var(--spacing-l);margin:var(--spacing-m) 0;}
+.cadence-label{display:flex;align-items:center;gap:var(--spacing-s);cursor:pointer;}
+.cadence-label input{accent-color:var(--color-primary);}
+.filter-section{margin-top:var(--spacing-l);}
+.filter-section summary{cursor:pointer;font-weight:600;color:var(--color-primary);margin-bottom:var(--spacing-m);}
+.filter-field{margin-bottom:var(--spacing-m);}
+.filter-field label{display:block;font-weight:500;margin-bottom:var(--spacing-s);font-size:.9rem;}
+.filter-field select{width:100%;padding:6px 10px;border:1px solid var(--fabric-neutral-grey-40);border-radius:6px;font-size:.85rem;min-height:70px;}
 @media (max-width:768px){.subscription-form{flex-direction:column;}.email-input{min-width:auto;}}
 </style>
 {% endblock %}
 {% block herotitle%}Email Notifications{% endblock %}
 {% block herosubtitle%}
-Stay informed about the latest Microsoft Fabric roadmap updates. Get weekly email summaries delivered straight to your inbox.
+Stay informed about the latest Microsoft Fabric roadmap updates. Choose daily or weekly digests delivered to your inbox.
 {% endblock %}
 {% block content %}
 <div class="container">
     <div class="subscription-section">
         <div class="card">
-            <h3>Weekly Email Updates</h3>
-            <p>Subscribe to receive weekly summaries of new roadmap items and updates.</p>
+            <h3>Subscribe to Updates</h3>
+            <p>Get roadmap change summaries delivered to your inbox.</p>
             <div class="subscription-item">
                 <div class="subscription-form">
                     <input type="email" id="email-input" placeholder="Enter your email address" class="email-input" />
                     <button id="subscribe-btn" class="btn btn-primary">Subscribe</button>
                 </div>
+
+                <div class="cadence-row">
+                    <label class="cadence-label">
+                        <input type="radio" name="cadence" value="weekly" checked> Weekly (Mondays)
+                    </label>
+                    <label class="cadence-label">
+                        <input type="radio" name="cadence" value="daily"> Daily
+                    </label>
+                </div>
+
+                <details class="filter-section">
+                    <summary>Filter by product, type, or status (optional)</summary>
+                    <div class="filter-field">
+                        <label for="sub-product-select">Products</label>
+                        <select id="sub-product-select" multiple></select>
+                    </div>
+                    <div class="filter-field">
+                        <label for="sub-type-select">Release Types</label>
+                        <select id="sub-type-select" multiple></select>
+                    </div>
+                    <div class="filter-field">
+                        <label for="sub-status-select">Statuses</label>
+                        <select id="sub-status-select" multiple></select>
+                    </div>
+                </details>
+
                 <div id="subscription-message" class="subscription-message"></div>
             </div>
             <div class="subscription-benefits">
                 <h4>What you'll receive:</h4>
                 <ul>
-                    <li>Weekly summaries of new and updated roadmap items</li>
-                    <li>Zero junk mail</li>
-                    <li>Easy unsubscribe option in every email</li>
+                    <li>Summaries of new and updated roadmap items (daily or weekly)</li>
+                    <li>Instant alerts for features you watch</li>
+                    <li>Zero junk mail — easy unsubscribe in every email</li>
                 </ul>
             </div>
         </div>
@@ -48,13 +82,66 @@ Stay informed about the latest Microsoft Fabric roadmap updates. Get weekly emai
 {% endblock %}
 {% block scripts %}
 <script>
-class EmailSubscription{constructor(){this.emailInput=document.getElementById('email-input');this.subscribeBtn=document.getElementById('subscribe-btn');this.messageDiv=document.getElementById('subscription-message');this.bindEvents();}
-bindEvents(){this.subscribeBtn.addEventListener('click',()=>this.subscribe());this.emailInput.addEventListener('keypress',e=>{if(e.key==='Enter'){this.subscribe();}});} 
-async subscribe(){const email=this.emailInput.value.trim();if(!this.validateEmail(email)){this.showMessage('Please enter a valid email address.','error');return;}this.setLoading(true);try{const response=await fetch('/api/subscribe',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email})});const result=await response.json();if(response.ok){this.showMessage(result.message,'success');this.emailInput.value='';}else{this.showMessage(result.error||'An error occurred. Please try again.','error');}}catch(err){this.showMessage('Network error. Please try again.','error');}finally{this.setLoading(false);}}
-validateEmail(e){return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);} 
-showMessage(m,t){this.messageDiv.textContent=m;this.messageDiv.className=`subscription-message ${t}`;this.messageDiv.style.display='block';}
-setLoading(l){this.subscribeBtn.disabled=l;this.subscribeBtn.textContent=l?'Subscribing...':'Subscribe';this.emailInput.disabled=l;}}
+async function loadFilterOptions() {
+    try {
+        const resp = await fetch('/api/filter-options');
+        const data = await resp.json();
+        populateSelect('sub-product-select', data.product_names || []);
+        populateSelect('sub-type-select', data.release_types || []);
+        populateSelect('sub-status-select', data.release_statuses || []);
+    } catch(e) { console.error('Failed to load filter options', e); }
+}
+function populateSelect(id, options) {
+    const sel = document.getElementById(id);
+    options.forEach(opt => {
+        const o = document.createElement('option');
+        o.value = opt; o.textContent = opt;
+        sel.appendChild(o);
+    });
+}
+function getSelected(id) {
+    return Array.from(document.getElementById(id).selectedOptions).map(o => o.value);
+}
 
-document.addEventListener('DOMContentLoaded',()=>{new EmailSubscription();});
+class EmailSubscription{
+    constructor(){
+        this.emailInput=document.getElementById('email-input');
+        this.subscribeBtn=document.getElementById('subscribe-btn');
+        this.messageDiv=document.getElementById('subscription-message');
+        this.bindEvents();
+    }
+    bindEvents(){
+        this.subscribeBtn.addEventListener('click',()=>this.subscribe());
+        this.emailInput.addEventListener('keypress',e=>{if(e.key==='Enter'){this.subscribe();}});
+    }
+    async subscribe(){
+        const email=this.emailInput.value.trim();
+        if(!this.validateEmail(email)){this.showMessage('Please enter a valid email address.','error');return;}
+        this.setLoading(true);
+        const cadence=document.querySelector('input[name="cadence"]:checked').value;
+        const products=getSelected('sub-product-select');
+        const types=getSelected('sub-type-select');
+        const statuses=getSelected('sub-status-select');
+        const body={email, cadence};
+        if(products.length) body.products=products;
+        if(types.length) body.types=types;
+        if(statuses.length) body.statuses=statuses;
+        try{
+            const response=await fetch('/api/subscribe',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+            const result=await response.json();
+            if(response.ok){this.showMessage(result.message,'success');this.emailInput.value='';}
+            else{this.showMessage(result.error||'An error occurred. Please try again.','error');}
+        }catch(err){this.showMessage('Network error. Please try again.','error');}
+        finally{this.setLoading(false);}
+    }
+    validateEmail(e){return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);}
+    showMessage(m,t){this.messageDiv.textContent=m;this.messageDiv.className=`subscription-message ${t}`;this.messageDiv.style.display='block';}
+    setLoading(l){this.subscribeBtn.disabled=l;this.subscribeBtn.textContent=l?'Subscribing...':'Subscribe';this.emailInput.disabled=l;}
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+    new EmailSubscription();
+    loadFilterOptions();
+});
 </script>
 {% endblock %}

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -7,68 +7,58 @@
 {% block twitter_description %}Subscribe to Microsoft Fabric roadmap email summaries. Choose daily or weekly digests, filter by product, and watch specific features.{% endblock %}
 {% block extra_head %}
 <style>
-.subscription-section{max-width:600px;margin:0 auto;padding:var(--spacing-xl) 0;}
-.subscription-benefits{margin-top:var(--spacing-l);padding:var(--spacing-l);background:var(--color-background);border-radius:8px;border-left:4px solid var(--color-primary);} 
-.subscription-benefits h4{margin-top:0;color:var(--color-primary);} 
-.subscription-benefits ul{margin:var(--spacing-m) 0 0 0;padding-left:var(--spacing-l);} 
-.subscription-benefits li{margin-bottom:var(--spacing-s);color:var(--color-text-secondary);} 
-.email-input{flex:1;min-width:200px;} 
-.subscription-form{display:flex;gap:var(--spacing-m);margin:var(--spacing-l) 0;} 
-.cadence-row{display:flex;gap:var(--spacing-l);margin:var(--spacing-m) 0;}
-.cadence-label{display:flex;align-items:center;gap:var(--spacing-s);cursor:pointer;}
-.cadence-label input{accent-color:var(--color-primary);}
-.filter-section{margin-top:var(--spacing-l);}
-.filter-section summary{cursor:pointer;font-weight:600;color:var(--color-primary);margin-bottom:var(--spacing-m);}
-.filter-field{margin-bottom:var(--spacing-m);}
-.filter-field label{display:block;font-weight:500;margin-bottom:var(--spacing-s);font-size:.9rem;}
-.filter-field select{width:100%;padding:6px 10px;border:1px solid var(--fabric-neutral-grey-40);border-radius:6px;font-size:.85rem;min-height:70px;}
-@media (max-width:768px){.subscription-form{flex-direction:column;}.email-input{min-width:auto;}}
+.subscribe-section { max-width: 640px; margin: 0 auto; padding: var(--spacing-xl) 0; }
+.subscribe-benefits { margin-top: var(--spacing-l); padding: var(--spacing-l); background: var(--fabric-neutral-grey-10); border-radius: 8px; border-left: 4px solid var(--fabric-primary); }
+.subscribe-benefits h4 { margin: 0 0 var(--spacing-s) 0; color: var(--fabric-primary); }
+.subscribe-benefits ul { margin: var(--spacing-s) 0 0 0; padding-left: var(--spacing-l); }
+.subscribe-benefits li { margin-bottom: var(--spacing-s); color: var(--fabric-neutral-grey-90); }
+@media (max-width: 768px) { .subscribe-section { padding: var(--spacing-l) var(--spacing-m); } }
 </style>
 {% endblock %}
-{% block herotitle%}Email Notifications{% endblock %}
-{% block herosubtitle%}
+{% block herotitle %}Email Notifications{% endblock %}
+{% block herosubtitle %}
 Stay informed about the latest Microsoft Fabric roadmap updates. Choose daily or weekly digests delivered to your inbox.
 {% endblock %}
 {% block content %}
 <div class="container">
-    <div class="subscription-section">
+    <div class="subscribe-section">
         <div class="card">
-            <h3>Subscribe to Updates</h3>
-            <p>Get roadmap change summaries delivered to your inbox.</p>
-            <div class="subscription-item">
-                <div class="subscription-form">
-                    <input type="email" id="email-input" placeholder="Enter your email address" class="email-input" />
-                    <button id="subscribe-btn" class="btn btn-primary">Subscribe</button>
-                </div>
+            <h3 class="card-title" style="font-size: var(--font-size-subtitle);">Subscribe to Updates</h3>
+            <p class="card-description">Get roadmap change summaries delivered to your inbox.</p>
 
-                <div class="cadence-row">
-                    <label class="cadence-label">
-                        <input type="radio" name="cadence" value="weekly" checked> Weekly (Mondays)
-                    </label>
-                    <label class="cadence-label">
-                        <input type="radio" name="cadence" value="daily"> Daily
-                    </label>
-                </div>
-
-                <details class="filter-section">
-                    <summary>Filter by product, type, or status (optional)</summary>
-                    <div class="filter-field">
-                        <label for="sub-product-select">Products</label>
-                        <select id="sub-product-select" multiple></select>
-                    </div>
-                    <div class="filter-field">
-                        <label for="sub-type-select">Release Types</label>
-                        <select id="sub-type-select" multiple></select>
-                    </div>
-                    <div class="filter-field">
-                        <label for="sub-status-select">Statuses</label>
-                        <select id="sub-status-select" multiple></select>
-                    </div>
-                </details>
-
-                <div id="subscription-message" class="subscription-message"></div>
+            <div class="subscription-form">
+                <input type="email" id="email-input" placeholder="Enter your email address" class="form-input" style="flex: 1; min-width: 200px;" />
+                <button id="subscribe-btn" class="button button-primary">Subscribe</button>
             </div>
-            <div class="subscription-benefits">
+
+            <div class="radio-group">
+                <label class="radio-label">
+                    <input type="radio" name="cadence" value="weekly" checked> Weekly (Mondays)
+                </label>
+                <label class="radio-label">
+                    <input type="radio" name="cadence" value="daily"> Daily
+                </label>
+            </div>
+
+            <details style="margin-top: var(--spacing-m);">
+                <summary style="cursor: pointer; font-weight: 600; color: var(--fabric-primary); margin-bottom: var(--spacing-m);">Filter by product, type, or status (optional)</summary>
+                <div class="form-group">
+                    <label for="sub-product-select">Products</label>
+                    <select id="sub-product-select" multiple></select>
+                </div>
+                <div class="form-group">
+                    <label for="sub-type-select">Release Types</label>
+                    <select id="sub-type-select" multiple></select>
+                </div>
+                <div class="form-group">
+                    <label for="sub-status-select">Statuses</label>
+                    <select id="sub-status-select" multiple></select>
+                </div>
+            </details>
+
+            <div id="subscription-message" class="subscription-message"></div>
+
+            <div class="subscribe-benefits">
                 <h4>What you'll receive:</h4>
                 <ul>
                     <li>Summaries of new and updated roadmap items (daily or weekly)</li>
@@ -76,6 +66,16 @@ Stay informed about the latest Microsoft Fabric roadmap updates. Choose daily or
                     <li>Zero junk mail — easy unsubscribe in every email</li>
                 </ul>
             </div>
+        </div>
+
+        <div class="card" style="margin-top: var(--spacing-l);">
+            <h3 class="card-title" style="font-size: var(--font-size-subtitle);">Already subscribed?</h3>
+            <p class="card-description">Enter your email to receive a link to manage your preferences, filters, and feature watches.</p>
+            <div class="subscription-form">
+                <input type="email" id="manage-email-input" placeholder="Enter your email address" class="form-input" style="flex: 1; min-width: 200px;" />
+                <button id="manage-btn" class="button button-primary" style="white-space:nowrap;">Send Link</button>
+            </div>
+            <div id="manage-message" class="subscription-message"></div>
         </div>
     </div>
 </div>
@@ -142,6 +142,44 @@ class EmailSubscription{
 document.addEventListener('DOMContentLoaded',()=>{
     new EmailSubscription();
     loadFilterOptions();
+
+    const manageBtn = document.getElementById('manage-btn');
+    const manageInput = document.getElementById('manage-email-input');
+    const manageMsg = document.getElementById('manage-message');
+
+    async function sendPreferencesLink() {
+        const email = manageInput.value.trim();
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            manageMsg.textContent = 'Please enter a valid email address.';
+            manageMsg.className = 'subscription-message error';
+            manageMsg.style.display = 'block';
+            return;
+        }
+        manageBtn.disabled = true;
+        manageBtn.textContent = 'Sending...';
+        try {
+            const resp = await fetch('/api/send-preferences-link', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email})
+            });
+            const result = await resp.json();
+            manageMsg.textContent = result.message || result.error;
+            manageMsg.className = 'subscription-message ' + (resp.ok ? 'success' : 'error');
+            manageMsg.style.display = 'block';
+            if (resp.ok) manageInput.value = '';
+        } catch (e) {
+            manageMsg.textContent = 'Network error. Please try again.';
+            manageMsg.className = 'subscription-message error';
+            manageMsg.style.display = 'block';
+        } finally {
+            manageBtn.disabled = false;
+            manageBtn.textContent = 'Send Link';
+        }
+    }
+
+    manageBtn.addEventListener('click', sendPreferencesLink);
+    manageInput.addEventListener('keypress', e => { if (e.key === 'Enter') sendPreferencesLink(); });
 });
 </script>
 {% endblock %}

--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -2,43 +2,42 @@
 {% block title %}Unsubscribe - Fabric GPS{% endblock %}
 {% block extra_head %}
 <meta name="robots" content="noindex, nofollow">
-<style>
-    .unsubscribe-container { max-width: 600px; margin: 2rem auto; padding: var(--spacing-xl); background: white; border-radius: 12px; box-shadow: var(--elevation-2); text-align: center; }
-    .success-icon, .error-icon, .pending-icon { font-size: 4rem; margin-bottom: var(--spacing-l); }
-    .success-message { color: var(--fabric-semantic-success); }
-    .error-message { color: var(--fabric-semantic-error); }
-</style>
 {% endblock %}
-
+{% block herotitle %}Unsubscribe{% endblock %}
+{% block herosubtitle %}Manage your Fabric GPS email subscription.{% endblock %}
 {% block content %}
-<div class="unsubscribe-container">
-    {% if pending %}
-        <div class="pending-icon">👋</div>
-        <h1 style="margin-top:0;">Confirm Unsubscribe</h1>
-        <p>Click the button below to unsubscribe from Fabric GPS weekly updates.</p>
-        <form method="POST" style="margin-top:var(--spacing-l);">
-          <input type="hidden" name="token" value="{{ token }}">
-          <button type="submit" class="button button-primary">Unsubscribe</button>
-        </form>
-        <p style="margin-top:var(--spacing-l);font-size:.85rem;color:var(--fabric-neutral-grey-90);">This page does nothing until you press Unsubscribe.</p>
-    {% elif success %}
-        <div class="success-icon">✅</div>
-        <h1 class="success-message">Successfully Unsubscribed</h1>
-        <p>You have been unsubscribed from Fabric GPS weekly updates. We're sorry to see you go!</p>
-        <p>A confirmation email has been sent. You can subscribe again at any time.</p>
-        <a href="/subscribe" class="button button-primary" style="margin-top: var(--spacing-l);">Re-subscribe</a>
-        <a href="/" class="button button-secondary" style="margin-top: var(--spacing-l);">Back to Home</a>
-    {% elif error %}
-        <div class="error-icon">❌</div>
-        <h1 class="error-message">Unsubscribe Failed</h1>
-        <p>{{ error }}</p>
-        <p>The unsubscribe link may be invalid or expired. If you continue to receive emails, please contact support.</p>
-        <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
-    {% else %}
-        <div class="error-icon">❓</div>
-        <h1 class="error-message">Invalid Request</h1>
-        <p>No unsubscribe token provided.</p>
-        <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
-    {% endif %}
+<div class="container">
+    <div class="page-card" style="text-align: center;">
+        {% if pending %}
+            <div class="status-icon">📬</div>
+            <h2 style="margin-top: 0;">Confirm Unsubscribe</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">Click the button below to unsubscribe from Fabric GPS updates.</p>
+            <form method="POST" style="margin-top: var(--spacing-l);">
+                <input type="hidden" name="token" value="{{ token }}">
+                <button type="submit" class="button button-primary">Unsubscribe</button>
+            </form>
+            <p style="margin-top: var(--spacing-l); font-size: var(--font-size-caption); color: var(--fabric-neutral-grey-90);">This page does nothing until you press Unsubscribe.</p>
+        {% elif success %}
+            <div class="status-icon">✅</div>
+            <h2 style="margin-top: 0; color: var(--fabric-semantic-success);">Successfully Unsubscribed</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">You have been unsubscribed from Fabric GPS updates. We're sorry to see you go!</p>
+            <p style="color: var(--fabric-neutral-grey-90);">A confirmation email has been sent. You can subscribe again at any time.</p>
+            <div class="card-actions" style="justify-content: center; margin-top: var(--spacing-l);">
+                <a href="/subscribe" class="button button-primary">Re-subscribe</a>
+                <a href="/" class="button button-secondary">Back to Home</a>
+            </div>
+        {% elif error %}
+            <div class="status-icon">❌</div>
+            <h2 style="margin-top: 0; color: var(--fabric-semantic-error);">Unsubscribe Failed</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">{{ error }}</p>
+            <p style="color: var(--fabric-neutral-grey-90);">The unsubscribe link may be invalid or expired. If you continue to receive emails, please contact support.</p>
+            <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
+        {% else %}
+            <div class="status-icon">❓</div>
+            <h2 style="margin-top: 0; color: var(--fabric-semantic-error);">Invalid Request</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">No unsubscribe token provided.</p>
+            <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
+        {% endif %}
+    </div>
 </div>
 {% endblock %}

--- a/templates/verify_email.html
+++ b/templates/verify_email.html
@@ -2,51 +2,42 @@
 {% block title %}Email Verification - Fabric GPS{% endblock %}
 {% block extra_head %}
 <meta name="robots" content="noindex, nofollow">
-<style>
-    .verification-container {
-        max-width: 600px;
-        margin: 2rem auto;
-        padding: var(--spacing-xl);
-        background: white;
-        border-radius: 12px;
-        box-shadow: var(--elevation-2);
-        text-align: center;
-    }
-    .success-icon,.error-icon,.pending-icon {
-        font-size: 4rem;
-        margin-bottom: var(--spacing-l);
-    }
-    .success-message { color: var(--fabric-semantic-success); }
-    .error-message { color: var(--fabric-semantic-error); }
-</style>
 {% endblock %}
-
+{% block herotitle %}Email Verification{% endblock %}
+{% block herosubtitle %}Confirm your email address to start receiving updates.{% endblock %}
 {% block content %}
-<div class="verification-container">
-    {% if pending %}
-        <div class="pending-icon">✉️</div>
-        <h1 style="margin-top:0;">Confirm Your Subscription</h1>
-        <p>Click the button below to verify your email and activate weekly updates every Monday.</p>
-        <form method="POST" style="margin-top:var(--spacing-l);">
-          <input type="hidden" name="token" value="{{ token }}">
-          <button type="submit" class="button button-primary">Verify Email</button>
-        </form>
-        <p style="margin-top:var(--spacing-l);font-size:.85rem;color:var(--fabric-neutral-grey-90);">Link valid for 24 hours. This page does nothing until you press Verify.</p>
-    {% elif success %}
-        <div class="success-icon">✅</div>
-        <h1 class="success-message">Email Verified!</h1>
-        <p>You will now receive weekly Microsoft Fabric roadmap change summaries.</p>
-        <a href="/" class="button button-primary" style="margin-top:var(--spacing-l);">Back to Home</a>
-    {% elif error %}
-        <div class="error-icon">❌</div>
-        <h1 class="error-message">Verification Failed</h1>
-        <p>{{ error }}</p>
-        <a href="/" class="button button-primary" style="margin-top:var(--spacing-l);">Back to Home</a>
-    {% else %}
-        <div class="error-icon">❓</div>
-        <h1 class="error-message">Invalid Request</h1>
-        <p>No verification token provided.</p>
-        <a href="/" class="button button-primary" style="margin-top:var(--spacing-l);">Back to Home</a>
-    {% endif %}
+<div class="container">
+    <div class="page-card" style="text-align: center;">
+        {% if pending %}
+            <div class="status-icon">✉️</div>
+            {% if watch_feature_name %}
+            <h2 style="margin-top: 0;">Start Watching a Feature</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">Verify your email to start watching <strong>{{ watch_feature_name }}</strong>. You'll be notified whenever it changes on the roadmap.</p>
+            {% else %}
+            <h2 style="margin-top: 0;">Confirm Your Subscription</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">Verify your email to activate {{ 'daily updates' if cadence == 'daily' else 'weekly updates every Monday' }}.</p>
+            {% endif %}
+            <form method="POST" style="margin-top: var(--spacing-l);">
+                <input type="hidden" name="token" value="{{ token }}">
+                <button type="submit" class="button button-primary">Verify Email</button>
+            </form>
+            <p style="margin-top: var(--spacing-l); font-size: var(--font-size-caption); color: var(--fabric-neutral-grey-90);">Link valid for 24 hours. This page does nothing until you press Verify.</p>
+        {% elif success %}
+            <div class="status-icon">✅</div>
+            <h2 style="margin-top: 0; color: var(--fabric-semantic-success);">Email Verified!</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">You will now receive Microsoft Fabric roadmap change summaries.</p>
+            <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
+        {% elif error %}
+            <div class="status-icon">❌</div>
+            <h2 style="margin-top: 0; color: var(--fabric-semantic-error);">Verification Failed</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">{{ error }}</p>
+            <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
+        {% else %}
+            <div class="status-icon">❓</div>
+            <h2 style="margin-top: 0; color: var(--fabric-semantic-error);">Invalid Request</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">No verification token provided.</p>
+            <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
+        {% endif %}
+    </div>
 </div>
 {% endblock %}

--- a/templates/watch.html
+++ b/templates/watch.html
@@ -23,17 +23,10 @@
         <p>The requested release item could not be found.</p>
         <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Roadmap</a>
 
-    {% elif success and already_verified %}
-        <div class="success-icon">✅</div>
-        <h1 class="success-message">Watch Added!</h1>
-        <p>You'll be alerted within an hour whenever <strong>{{ feature_name }}</strong> changes.</p>
-        <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-top: var(--spacing-m);">Manage your watches anytime from the link in your emails.</p>
-        <a href="/release/{{ release_item_id }}" class="button button-primary" style="margin-top: var(--spacing-l);">← Back to Release</a>
-
-    {% elif success and not already_verified %}
+    {% elif success %}
         <div class="success-icon">📧</div>
         <h1 style="margin-top:0;">Check Your Email</h1>
-        <p>We've sent a verification email to confirm your subscription.</p>
+        <p>We've sent a verification email to confirm your watch request.</p>
         <p>Once verified, you'll receive alerts whenever <strong>{{ feature_name }}</strong> changes.</p>
         <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-top: var(--spacing-m);">Make sure to check your Spam or Junk folder.</p>
         <a href="/release/{{ release_item_id }}" class="button button-secondary" style="margin-top: var(--spacing-l);">← Back to Release</a>

--- a/templates/watch.html
+++ b/templates/watch.html
@@ -1,0 +1,66 @@
+{% extends 'base.html' %}
+{% block title %}Watch {{ feature_name or 'Feature' }} — Fabric GPS{% endblock %}
+{% block extra_head %}
+<meta name="robots" content="noindex, nofollow">
+<style>
+    .watch-container { max-width: 600px; margin: 2rem auto; padding: var(--spacing-xl); background: white; border-radius: 12px; box-shadow: var(--elevation-2); text-align: center; }
+    .watch-feature-name { font-size: 1.1rem; font-weight: 600; color: var(--fabric-neutral-grey-130); margin-bottom: var(--spacing-s); }
+    .watch-product { font-size: .9rem; color: var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-l); }
+    .watch-form { margin: var(--spacing-xl) 0; }
+    .watch-form input[type="email"] { width: 100%; max-width: 400px; padding: 10px 14px; border: 1px solid var(--fabric-neutral-grey-40); border-radius: 8px; font-size: 1rem; margin-bottom: var(--spacing-m); }
+    .success-icon, .error-icon { font-size: 4rem; margin-bottom: var(--spacing-l); }
+    .success-message { color: var(--fabric-semantic-success); }
+    .error-message { color: var(--fabric-semantic-error); }
+    .error-inline { color: var(--fabric-semantic-error); font-size: .9rem; margin-bottom: var(--spacing-m); }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="watch-container">
+    {% if not release_item_id %}
+        <div class="error-icon">❌</div>
+        <h1 class="error-message">Release Not Found</h1>
+        <p>The requested release item could not be found.</p>
+        <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Roadmap</a>
+
+    {% elif success and already_verified %}
+        <div class="success-icon">✅</div>
+        <h1 class="success-message">Watch Added!</h1>
+        <p>You'll be alerted within an hour whenever <strong>{{ feature_name }}</strong> changes.</p>
+        <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-top: var(--spacing-m);">Manage your watches anytime from the link in your emails.</p>
+        <a href="/release/{{ release_item_id }}" class="button button-primary" style="margin-top: var(--spacing-l);">← Back to Release</a>
+
+    {% elif success and not already_verified %}
+        <div class="success-icon">📧</div>
+        <h1 style="margin-top:0;">Check Your Email</h1>
+        <p>We've sent a verification email to confirm your subscription.</p>
+        <p>Once verified, you'll receive alerts whenever <strong>{{ feature_name }}</strong> changes.</p>
+        <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-top: var(--spacing-m);">Make sure to check your Spam or Junk folder.</p>
+        <a href="/release/{{ release_item_id }}" class="button button-secondary" style="margin-top: var(--spacing-l);">← Back to Release</a>
+
+    {% else %}
+        <div style="font-size: 3rem; margin-bottom: var(--spacing-l);">👁️</div>
+        <h1 style="margin-top:0;">Watch this Feature</h1>
+        <div class="watch-feature-name">{{ feature_name }}</div>
+        <div class="watch-product">{{ product_name }}</div>
+        <p>Get alerted within an hour whenever this feature is updated on the roadmap.</p>
+
+        {% if error %}
+        <p class="error-inline">{{ error }}</p>
+        {% endif %}
+
+        <form method="POST" class="watch-form">
+            <div>
+                <input type="email" name="email" placeholder="Enter your email address" required autofocus />
+            </div>
+            <button type="submit" class="button button-primary">Subscribe & Watch</button>
+        </form>
+
+        <p style="font-size:.8rem; color:var(--fabric-neutral-grey-90);">
+            If you're already subscribed, the watch will be added instantly.
+            Otherwise, you'll receive a verification email first.
+        </p>
+        <a href="/release/{{ release_item_id }}" class="button button-secondary" style="margin-top: var(--spacing-m);">← Back to Release</a>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/watch.html
+++ b/templates/watch.html
@@ -34,7 +34,7 @@
                 <button type="submit" class="button button-primary">Subscribe &amp; Watch</button>
             </form>
             <p style="margin-top: var(--spacing-l); font-size: var(--font-size-caption); color: var(--fabric-neutral-grey-90);">
-                If you're already subscribed, the watch will be added instantly.
+                We'll send a verification email to confirm your watch request, even if you're already subscribed.
             </p>
         {% endif %}
     </div>

--- a/templates/watch.html
+++ b/templates/watch.html
@@ -2,58 +2,41 @@
 {% block title %}Watch {{ feature_name or 'Feature' }} — Fabric GPS{% endblock %}
 {% block extra_head %}
 <meta name="robots" content="noindex, nofollow">
-<style>
-    .watch-container { max-width: 600px; margin: 2rem auto; padding: var(--spacing-xl); background: white; border-radius: 12px; box-shadow: var(--elevation-2); text-align: center; }
-    .watch-feature-name { font-size: 1.1rem; font-weight: 600; color: var(--fabric-neutral-grey-130); margin-bottom: var(--spacing-s); }
-    .watch-product { font-size: .9rem; color: var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-l); }
-    .watch-form { margin: var(--spacing-xl) 0; }
-    .watch-form input[type="email"] { width: 100%; max-width: 400px; padding: 10px 14px; border: 1px solid var(--fabric-neutral-grey-40); border-radius: 8px; font-size: 1rem; margin-bottom: var(--spacing-m); }
-    .success-icon, .error-icon { font-size: 4rem; margin-bottom: var(--spacing-l); }
-    .success-message { color: var(--fabric-semantic-success); }
-    .error-message { color: var(--fabric-semantic-error); }
-    .error-inline { color: var(--fabric-semantic-error); font-size: .9rem; margin-bottom: var(--spacing-m); }
-</style>
 {% endblock %}
-
+{% block herotitle %}Watch a Feature{% endblock %}
+{% block herosubtitle %}Get notified when a specific roadmap item changes.{% endblock %}
 {% block content %}
-<div class="watch-container">
-    {% if not release_item_id %}
-        <div class="error-icon">❌</div>
-        <h1 class="error-message">Release Not Found</h1>
-        <p>The requested release item could not be found.</p>
-        <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Roadmap</a>
-
-    {% elif success %}
-        <div class="success-icon">📧</div>
-        <h1 style="margin-top:0;">Check Your Email</h1>
-        <p>We've sent a verification email to confirm your watch request.</p>
-        <p>Once verified, you'll receive alerts whenever <strong>{{ feature_name }}</strong> changes.</p>
-        <p style="font-size:.85rem; color:var(--fabric-neutral-grey-90); margin-top: var(--spacing-m);">Make sure to check your Spam or Junk folder.</p>
-        <a href="/release/{{ release_item_id }}" class="button button-secondary" style="margin-top: var(--spacing-l);">← Back to Release</a>
-
-    {% else %}
-        <div style="font-size: 3rem; margin-bottom: var(--spacing-l);">👁️</div>
-        <h1 style="margin-top:0;">Watch this Feature</h1>
-        <div class="watch-feature-name">{{ feature_name }}</div>
-        <div class="watch-product">{{ product_name }}</div>
-        <p>Get alerted within an hour whenever this feature is updated on the roadmap.</p>
-
+<div class="container">
+    <div class="page-card" style="text-align: center;">
         {% if error %}
-        <p class="error-inline">{{ error }}</p>
+            <div class="status-icon">❌</div>
+            <h2 style="margin-top: 0; color: var(--fabric-semantic-error);">{{ error }}</h2>
+            <a href="/" class="button button-primary" style="margin-top: var(--spacing-l);">Back to Home</a>
+        {% elif success %}
+            <div class="status-icon">✅</div>
+            <h2 style="margin-top: 0;">Watch Request Submitted</h2>
+            <p style="color: var(--fabric-neutral-grey-90);">We've sent a verification email to confirm your watch request.</p>
+            <a href="/release/{{ release_item_id }}" class="button button-secondary" style="margin-top: var(--spacing-l);">Back to Release</a>
+        {% else %}
+            <h2 style="margin-top: 0;">Watch this Feature</h2>
+            <p style="font-weight: 600; color: var(--fabric-neutral-grey-160); margin-bottom: var(--spacing-s);">{{ feature_name }}</p>
+            <p style="font-size: var(--font-size-body); color: var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-l);">{{ product_name }}</p>
+
+            <p style="color: var(--fabric-neutral-grey-90); margin-bottom: var(--spacing-l);">
+                Enter your email to get notified when this feature is updated on the roadmap.
+            </p>
+
+            <form method="POST">
+                <input type="hidden" name="release_item_id" value="{{ release_item_id }}">
+                <div style="max-width: 400px; margin: 0 auto var(--spacing-m) auto;">
+                    <input type="email" name="email" placeholder="Enter your email address" required class="form-input" />
+                </div>
+                <button type="submit" class="button button-primary">Subscribe &amp; Watch</button>
+            </form>
+            <p style="margin-top: var(--spacing-l); font-size: var(--font-size-caption); color: var(--fabric-neutral-grey-90);">
+                If you're already subscribed, the watch will be added instantly.
+            </p>
         {% endif %}
-
-        <form method="POST" class="watch-form">
-            <div>
-                <input type="email" name="email" placeholder="Enter your email address" required autofocus />
-            </div>
-            <button type="submit" class="button button-primary">Subscribe & Watch</button>
-        </form>
-
-        <p style="font-size:.8rem; color:var(--fabric-neutral-grey-90);">
-            If you're already subscribed, the watch will be added instantly.
-            Otherwise, you'll receive a verification email first.
-        </p>
-        <a href="/release/{{ release_item_id }}" class="button button-secondary" style="margin-top: var(--spacing-m);">← Back to Release</a>
-    {% endif %}
+    </div>
 </div>
 {% endblock %}

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -14,6 +14,7 @@ import time
 import hashlib
 import requests
 import logging
+import sqlalchemy.exc
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 from typing import List, Dict, Any, Optional
@@ -200,9 +201,11 @@ class WeeklyEmailSender:
                         content_json=content,
                     ))
             logger.info("Cached content for key=%s (%d items)", cache_key[:40], len(items))
+        except sqlalchemy.exc.IntegrityError:
+            # Another process already cached this key; safe to ignore
+            logger.info("Cache key=%s already exists (concurrent write), using generated content", cache_key[:40])
         except Exception as e:
-            # IntegrityError means another process cached it; that's fine
-            logger.warning(f"Cache write failed for key={cache_key[:40]}: {e}")
+            logger.error(f"Cache write failed for key={cache_key[:40]}: {e}")
 
         return items, ai_summary
 
@@ -441,7 +444,7 @@ class WeeklyEmailSender:
     def update_last_email_sent(self, subscription_id: str):
         """Update the last_email_sent timestamp for a subscription"""
         try:
-            engine = make_engine()
+            engine = self._engine or make_engine()
             from sqlalchemy.orm import sessionmaker
             SessionLocal = sessionmaker(bind=engine, future=True)
             with SessionLocal() as session:

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -221,18 +221,37 @@ class WeeklyEmailSender:
 
             sent_count = 0
             error_count = 0
-            # Azure Communication Services quota: 30 emails/minute
-            MIN_SEND_INTERVAL = 2.0  # seconds between sends (60/30)
+            # Azure Communication Services quota: 100 emails/min, 1000 emails/hr.
+            # Reserve ~20% headroom for transactional emails (verification, preferences links)
+            # sent by the web server from the same quota.
+            MIN_SEND_INTERVAL = 0.75  # seconds between sends (~80/min)
+            MAX_HOURLY_SENDS = 800    # leave 200/hr for transactional emails
             last_send_time = 0.0
+            hourly_sent = 0
+            hourly_window_start = time.monotonic()
 
             for subscription in subscriptions:
                 try:
+                    # Enforce hourly quota
+                    elapsed_in_window = time.monotonic() - hourly_window_start
+                    if elapsed_in_window >= 3600:
+                        hourly_sent = 0
+                        hourly_window_start = time.monotonic()
+                    elif hourly_sent >= MAX_HOURLY_SENDS:
+                        wait_time = 3600 - elapsed_in_window
+                        logger.info(f"Hourly quota reached ({MAX_HOURLY_SENDS}), pausing {wait_time:.0f}s")
+                        time.sleep(wait_time)
+                        hourly_sent = 0
+                        hourly_window_start = time.monotonic()
+
+                    # Enforce per-minute rate
                     elapsed = time.monotonic() - last_send_time
                     if elapsed < MIN_SEND_INTERVAL:
                         time.sleep(MIN_SEND_INTERVAL - elapsed)
 
                     if self.send_digest_email(subscription):
                         sent_count += 1
+                        hourly_sent += 1
                         last_send_time = time.monotonic()
                         self.update_last_email_sent(subscription.id)
                     else:
@@ -252,12 +271,25 @@ class WeeklyEmailSender:
 
                 for sub, changed_watches in watch_results:
                     try:
+                        # Enforce hourly quota (shared with digest sends)
+                        elapsed_in_window = time.monotonic() - hourly_window_start
+                        if elapsed_in_window >= 3600:
+                            hourly_sent = 0
+                            hourly_window_start = time.monotonic()
+                        elif hourly_sent >= MAX_HOURLY_SENDS:
+                            wait_time = 3600 - elapsed_in_window
+                            logger.info(f"Hourly quota reached ({MAX_HOURLY_SENDS}), pausing {wait_time:.0f}s")
+                            time.sleep(wait_time)
+                            hourly_sent = 0
+                            hourly_window_start = time.monotonic()
+
                         elapsed = time.monotonic() - last_send_time
                         if elapsed < MIN_SEND_INTERVAL:
                             time.sleep(MIN_SEND_INTERVAL - elapsed)
 
                         if self.send_watch_alert_email(sub, changed_watches):
                             watch_sent += 1
+                            hourly_sent += 1
                             last_send_time = time.monotonic()
                             hash_updates = [(w['watch_id'], w['current_hash']) for w in changed_watches]
                             update_watch_hashes(engine, hash_updates)

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -141,8 +141,22 @@ class WeeklyEmailSender:
         items = list(self._fetch_raw_changes())
 
         if subscription.email_cadence == 'daily':
-            cutoff = (datetime.utcnow() - timedelta(hours=24)).isoformat()
-            items = [c for c in items if (c.get('last_modified') or '') >= cutoff]
+            # `/api/releases` exposes `last_modified` as a date-only string (`YYYY-MM-DD`),
+            # so daily filtering must use a date-based cutoff rather than a timestamp.
+            cutoff_date = (datetime.utcnow() - timedelta(days=1)).date()
+            filtered_items = []
+            for c in items:
+                last_modified = c.get('last_modified')
+                if not last_modified:
+                    continue
+                try:
+                    last_modified_date = datetime.strptime(last_modified, '%Y-%m-%d').date()
+                except ValueError:
+                    logger.warning("Skipping item with invalid last_modified value: %s", last_modified)
+                    continue
+                if last_modified_date >= cutoff_date:
+                    filtered_items.append(c)
+            items = filtered_items
 
         if subscription.product_filter:
             products = {p.strip().lower() for p in subscription.product_filter.split(',') if p.strip()}

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -13,7 +13,8 @@ import json
 import time
 import requests
 import logging
-from datetime import datetime, date, timedelta
+from datetime import datetime, timedelta
+from urllib.parse import urlencode
 from typing import List, Dict, Any, Optional
 from azure.communication.email import EmailClient
 
@@ -55,7 +56,6 @@ logger.info('Fabric-GPS Email Batch Job started')
 
 
 class WeeklyEmailSender:
-    CONTENT_CACHE_TTL = 24 * 60 * 60  # 24 hours in seconds
 
     def __init__(self):
         # Azure Communication Services configuration
@@ -71,6 +71,9 @@ class WeeklyEmailSender:
         # Initialize Azure Email Client
         self.email_client = EmailClient.from_connection_string(self.connection_string)
 
+        # In-memory cache for raw 7-day data (populated once per run)
+        self._raw_changes = None
+
     @staticmethod
     def _add_utm(url: str, source: str = 'email', medium: str = 'email',
                  campaign: str = 'weekly-digest') -> str:
@@ -83,63 +86,103 @@ class WeeklyEmailSender:
         sep = '&' if '?' in url else '?'
         return f"{url}{sep}{params}"
 
-    def _load_or_generate_content(self):
-        """Return (all_changes, ai_summary), using a 24-hour DB cache.
+    def _fetch_raw_changes(self) -> List[Dict[str, Any]]:
+        """Fetch all 7-day changes, cached in-memory for this run."""
+        if self._raw_changes is None:
+            self._raw_changes = self._fetch_all_changes_unfiltered()
+            logger.info("Fetched %d raw changes from API", len(self._raw_changes))
+        return self._raw_changes
 
-        On the first run of the day the data is fetched from the API and
-        an AI summary is generated, then stored in the email_content_cache
-        table. Subsequent hourly runs within the TTL reuse the cached
-        content so every subscriber batch gets identical emails regardless
-        of when their batch is processed.
+    @staticmethod
+    def _build_cache_key(subscription: EmailSubscriptionModel) -> str:
+        """Build a deterministic cache key from subscriber cadence + filters."""
+        parts = [
+            subscription.email_cadence or 'weekly',
+            (subscription.product_filter or '').strip().lower(),
+            (subscription.release_type_filter or '').strip().lower(),
+            (subscription.release_status_filter or '').strip().lower(),
+        ]
+        return '|'.join(parts)[:255]
+
+    def _get_subscriber_content(self, subscription: EmailSubscriptionModel):
+        """Return (changes, ai_summary) for a subscriber, using per-date per-filter DB cache.
+
+        On the first call for a given (date, filter-combo) the content is
+        generated from the raw 7-day data, an AI summary is produced, and
+        both are stored in the cache. Subsequent calls with the same key
+        on the same date reuse the cached content so every subscriber
+        with identical settings gets the exact same email.
         """
         from sqlalchemy.orm import sessionmaker
+        from sqlalchemy import select as sa_select
+
+        cache_key = self._build_cache_key(subscription)
+        cache_date = datetime.utcnow().strftime('%Y-%m-%d')
 
         engine = make_engine()
         SessionLocal = sessionmaker(bind=engine, future=True)
 
-        # Try reading the cache from DB
+        # Try DB cache
         try:
             with SessionLocal() as session:
-                row = session.get(EmailContentCacheModel, 1)
-                if row and row.generated_at:
-                    age_seconds = (datetime.utcnow() - row.generated_at).total_seconds()
-                    if age_seconds < self.CONTENT_CACHE_TTL:
-                        cached = json.loads(row.content_json)
-                        logger.info("Using cached email content (age: %.0f min)", age_seconds / 60)
-                        return cached['changes'], cached.get('ai_summary')
-                    logger.info("Content cache expired, regenerating")
+                row = session.scalar(
+                    sa_select(EmailContentCacheModel)
+                    .where(EmailContentCacheModel.cache_date == cache_date)
+                    .where(EmailContentCacheModel.cache_key == cache_key)
+                )
+                if row:
+                    cached = json.loads(row.content_json)
+                    logger.info("Cache hit for key=%s date=%s", cache_key[:40], cache_date)
+                    return cached['changes'], cached.get('ai_summary')
         except Exception as e:
-            logger.warning(f"Could not read content cache, regenerating: {e}")
+            logger.warning(f"Cache read failed for key={cache_key[:40]}: {e}")
 
-        # Generate fresh content
-        all_changes = self._fetch_all_changes_unfiltered()
-        ai_summary = self.generate_ai_summary(all_changes)
-        if ai_summary:
-            logger.info("AI summary generated successfully")
-        else:
-            logger.info("AI summary not available, emails will be sent without it")
+        # Cache miss: filter from raw data
+        items = list(self._fetch_raw_changes())
 
-        # Write cache to DB
+        if subscription.email_cadence == 'daily':
+            cutoff = (datetime.utcnow() - timedelta(hours=24)).isoformat()
+            items = [c for c in items if (c.get('last_modified') or '') >= cutoff]
+
+        if subscription.product_filter:
+            products = {p.strip().lower() for p in subscription.product_filter.split(',') if p.strip()}
+            if products:
+                items = [c for c in items if (c.get('product_name') or '').lower() in products]
+
+        if subscription.release_type_filter:
+            types = {t.strip() for t in subscription.release_type_filter.split(',') if t.strip()}
+            if types:
+                items = [c for c in items if c.get('release_type') in types]
+
+        if subscription.release_status_filter:
+            statuses = {s.strip() for s in subscription.release_status_filter.split(',') if s.strip()}
+            if statuses:
+                items = [c for c in items if c.get('release_status') in statuses]
+
+        items.sort(key=lambda x: x.get('last_modified') or '', reverse=True)
+        items = items[:50]
+
+        # Generate AI summary specific to this filtered set
+        ai_summary = self.generate_ai_summary(items) if items else None
+
+        # Write to cache
         try:
-            content = json.dumps({'changes': all_changes, 'ai_summary': ai_summary},
+            content = json.dumps({'changes': items, 'ai_summary': ai_summary},
                                  separators=(',', ':'))
             with SessionLocal() as session:
                 with session.begin():
-                    row = session.get(EmailContentCacheModel, 1)
-                    if row:
-                        row.generated_at = datetime.utcnow()
-                        row.content_json = content
-                    else:
-                        session.add(EmailContentCacheModel(
-                            id=1,
-                            generated_at=datetime.utcnow(),
-                            content_json=content,
-                        ))
-            logger.info("Email content cached in DB (%d changes)", len(all_changes))
+                    session.add(EmailContentCacheModel(
+                        cache_date=cache_date,
+                        cache_key=cache_key,
+                        generated_at=datetime.utcnow(),
+                        content_json=content,
+                    ))
+            logger.info("Cached content for key=%s (%d items)", cache_key[:40], len(items))
         except Exception as e:
-            logger.warning(f"Could not write content cache: {e}")
+            # IntegrityError means another process cached it; that's fine
+            logger.warning(f"Cache write failed for key={cache_key[:40]}: {e}")
 
-        return all_changes, ai_summary
+        return items, ai_summary
 
     def send_emails(self):
         """Send digest and watch alert emails to eligible subscribers."""
@@ -149,10 +192,6 @@ class WeeklyEmailSender:
             # --- Digest queue: daily/weekly subscribers whose interval elapsed ---
             subscriptions = get_digest_eligible_subscriptions(engine)
             logger.info(f"Digest queue: {len(subscriptions)} eligible subscriptions")
-
-            # Load or generate email content (cached for 24h so all
-            # hourly batches use the same data)
-            all_changes, ai_summary = self._load_or_generate_content()
 
             sent_count = 0
             error_count = 0
@@ -166,7 +205,7 @@ class WeeklyEmailSender:
                     if elapsed < MIN_SEND_INTERVAL:
                         time.sleep(MIN_SEND_INTERVAL - elapsed)
 
-                    if self.send_digest_email(subscription, ai_summary=ai_summary):
+                    if self.send_digest_email(subscription):
                         sent_count += 1
                         last_send_time = time.monotonic()
                         self.update_last_email_sent(subscription.id)
@@ -224,11 +263,11 @@ class WeeklyEmailSender:
     # Keep old name as alias for backward compatibility
     send_weekly_emails = send_emails
 
-    def send_digest_email(self, subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None) -> bool:
+    def send_digest_email(self, subscription: EmailSubscriptionModel) -> bool:
         """Send a digest email to a single subscriber."""
         try:
-            # Get changes using JSON API with subscriber's filters
-            changes = self.get_changes_from_api(subscription)
+            # Get filtered changes + AI summary from per-key cache
+            changes, ai_summary = self._get_subscriber_content(subscription)
             
             if not changes:
                 logger.info(f"No changes for {subscription.email}, skipping")
@@ -237,7 +276,8 @@ class WeeklyEmailSender:
             # Generate email content
             cadence_label = "Daily" if subscription.email_cadence == "daily" else "Weekly"
             subject = f"Fabric GPS {cadence_label} Update - {len(changes)} Changes"
-            html_content = self.generate_email_html(changes, subscription, ai_summary=ai_summary)
+
+            html_content = self.generate_email_html(changes, subscription, ai_summary=ai_summary, cadence_label=cadence_label)
             text_content = self.generate_email_text(changes, subscription, ai_summary=ai_summary)
             
             # Send email using Azure Communication Services
@@ -375,52 +415,8 @@ class WeeklyEmailSender:
             logger.error(f"AI summary generation failed: {e}")
             return None
 
-# Replace the existing get_changes_from_api method with:
-
-    def get_changes_from_api(self, subscription: EmailSubscriptionModel) -> List[Dict[str, Any]]:
-        """
-        Get last week's changes honoring subscriber filters.
-        Filters from the cached unfiltered content when available,
-        falling back to a live API fetch if no cache exists.
-        """
-        try:
-            all_changes, _ = self._load_or_generate_content()
-            items = list(all_changes)
-
-            # Apply optional product filter
-            if subscription.product_filter:
-                products = {p.strip().lower() for p in subscription.product_filter.split(',') if p.strip()}
-                if products:
-                    items = [c for c in items if (c.get('product_name') or '').lower() in products]
-
-            # Apply optional release type/status filters
-            if subscription.release_type_filter:
-                types = {t.strip() for t in subscription.release_type_filter.split(',') if t.strip()}
-                if types:
-                    items = [c for c in items if c.get('release_type') in types]
-
-            if subscription.release_status_filter:
-                statuses = {s.strip() for s in subscription.release_status_filter.split(',') if s.strip()}
-                if statuses:
-                    items = [c for c in items if c.get('release_status') in statuses]
-
-            # Robust sort by last_modified (ISO date or fallback)
-            def _lm_key(x):
-                lm = x.get('last_modified')
-                return lm or ""
-            items.sort(key=_lm_key, reverse=True)
-
-            return items[:50]
-
-        except requests.RequestException as e:
-            logger.error(f"Network/API error retrieving changes for {subscription.email}: {e}")
-            return []
-        except Exception as e:
-            logger.error(f"Unexpected error processing changes for {subscription.email}: {e}")
-            return []
-
     def update_last_email_sent(self, subscription_id: str):
-        """Update the last_email_sent date for a subscription"""
+        """Update the last_email_sent timestamp for a subscription"""
         try:
             engine = make_engine()
             from sqlalchemy.orm import sessionmaker
@@ -428,7 +424,7 @@ class WeeklyEmailSender:
             with SessionLocal() as session:
                 subscription = session.get(EmailSubscriptionModel, subscription_id)
                 if subscription:
-                    subscription.last_email_sent = date.today()
+                    subscription.last_email_sent = datetime.utcnow()
                     session.commit()
         except Exception as e:
             logger.error(f"Error updating last_email_sent for {subscription_id}: {e}")
@@ -461,10 +457,11 @@ class WeeklyEmailSender:
             f'{self.escape_html(label)}</a>'
         )
 
-    def generate_email_html(self, changes: List[Dict[str, Any]], subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None) -> str:
+    def generate_email_html(self, changes: List[Dict[str, Any]], subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None, cadence_label: str = "Weekly") -> str:
         """Generate HTML email content styled to match index page design."""
-        unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={subscription.unsubscribe_token}")
-        preferences_url = self._add_utm(f"{self.base_url}/preferences?token={subscription.unsubscribe_token}")
+        utm_campaign = "daily-digest" if cadence_label == "Daily" else "weekly-digest"
+        unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={subscription.unsubscribe_token}", campaign=utm_campaign)
+        preferences_url = self._add_utm(f"{self.base_url}/preferences?token={subscription.unsubscribe_token}", campaign=utm_campaign)
 
         # Style tokens (aligned with site)
         BODY_BG = "#f3f2f1"
@@ -475,20 +472,22 @@ class WeeklyEmailSender:
         TEXT_SECONDARY = "#605e5c"
         HERO_GRADIENT = "linear-gradient(135deg,#19433c 0%,#286c61 100%)"
 
-        preheader = f"{len(changes)} Fabric roadmap item change(s) this week." if changes else "Your weekly Fabric GPS update." 
+        preheader = f"{len(changes)} Fabric roadmap item change(s) in this {cadence_label.lower()} update." if changes else f"Your {cadence_label.lower()} Fabric GPS update."
 
         def fmt_date(dt_str: str, fallback: str = "TBD", out_fmt: str = "%b %d, %Y") -> str:
             if not dt_str:
                 return fallback
-            for pattern in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S.%fZ"):
-                try:
-                    return datetime.strptime(dt_str[:len(pattern)], pattern).strftime(out_fmt)
-                except Exception:
-                    continue
-            return dt_str
+            try:
+                return datetime.fromisoformat(dt_str.replace('Z', '+00:00')).strftime(out_fmt)
+            except (ValueError, TypeError):
+                return dt_str
+
+        MAX_EMAIL_CARDS = 20
+        total_changes = len(changes)
+        displayed_changes = changes[:MAX_EMAIL_CARDS]
 
         card_blocks: List[str] = []
-        for change in changes:
+        for change in displayed_changes:
             feature_name = change.get('feature_name') or 'Unnamed Feature'
             product_name = change.get('product_name') or 'Unknown'
             release_type = change.get('release_type') or 'Unknown'
@@ -500,7 +499,7 @@ class WeeklyEmailSender:
             release_type_variant = "success" if release_type == "General availability" else "warning"
             release_status_variant = "success" if release_status == "Shipped" else "warning"
             is_removed = change.get('active') is False
-            detail_url = self._add_utm(f"{self.base_url}/release/{rel_id}") if rel_id else self._add_utm(self.base_url)
+            detail_url = self._add_utm(f"{self.base_url}/release/{rel_id}", campaign=utm_campaign) if rel_id else self._add_utm(self.base_url, campaign=utm_campaign)
             removed_badge = self._build_badge("Removed", "removed") if is_removed else ""
             badges_html = (
                 removed_badge +
@@ -511,6 +510,28 @@ class WeeklyEmailSender:
             card_blocks.append(
                 f"""
                 <div style=\"background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px;\n                            padding:18px;margin:0 0 18px 0;box-shadow:{CARD_SHADOW};\">\n                    <h3 style=\"margin:0 0 10px 0;font-size:18px;line-height:1.3;color:{TEXT_PRIMARY};font-weight:600;\">\n                        <a href=\"{self.escape_html(detail_url)}\" style=\"color:{TEXT_PRIMARY};text-decoration:none;\">{self.escape_html(feature_name)}\n                        </a>\n                    </h3>\n                    <div style=\"margin:0 0 10px 0;\">{badges_html}</div>\n                    <div style=\"font-size:12px;color:{TEXT_SECONDARY};margin:0 0 12px 0;\">\n                        <strong>Last Modified:</strong> {self.escape_html(modified_date)} &nbsp;|&nbsp;\n                        <strong>Release Date:</strong> {self.escape_html(release_date)}\n                    </div>\n                    <p style=\"margin:0 0 14px 0;font-size:14px;line-height:1.5;color:{TEXT_PRIMARY};\">{self.escape_html(description)}\n                    </p>\n                    {self._build_button(detail_url, "View in Fabric GPS")}\n                </div>\n                """
+            )
+
+        if total_changes > MAX_EMAIL_CARDS:
+            remaining = total_changes - MAX_EMAIL_CARDS
+            browse_params = {
+                'modified_within_days': 1 if cadence_label == 'Daily' else 7,
+                'include_inactive': 'true',
+            }
+            if subscription.product_filter and ',' not in subscription.product_filter:
+                browse_params['product_name'] = subscription.product_filter.strip()
+            if subscription.release_type_filter and ',' not in subscription.release_type_filter:
+                browse_params['release_type'] = subscription.release_type_filter.strip()
+            if subscription.release_status_filter and ',' not in subscription.release_status_filter:
+                browse_params['release_status'] = subscription.release_status_filter.strip()
+            browse_url = self._add_utm(f"{self.base_url}/?{urlencode(browse_params)}", campaign=utm_campaign)
+            card_blocks.append(
+                f'<div style="background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px;'
+                f'padding:22px;margin:0 0 18px 0;box-shadow:{CARD_SHADOW};text-align:center;">'
+                f'<p style="margin:0 0 14px 0;font-size:15px;color:{TEXT_SECONDARY};">'
+                f'... and {remaining} more change(s)</p>'
+                f'{self._build_button(browse_url, "View All on Fabric GPS")}'
+                f'</div>'
             )
 
         if not card_blocks:
@@ -529,22 +550,25 @@ class WeeklyEmailSender:
                 f'<div style="background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px;'
                 f'padding:20px 22px;box-shadow:{CARD_SHADOW};">'
                 f'<h2 style="margin:0 0 10px 0;font-size:16px;color:{TEXT_PRIMARY};font-weight:600;">'
-                f'\U0001f4a1 AI Weekly Summary</h2>'
+                f'\U0001f4a1 AI Summary</h2>'
                 f'<p style="margin:0;font-size:14px;line-height:1.6;color:{TEXT_SECONDARY};">'
                 f'{self.escape_html(ai_summary)}</p>'
                 f'</div></td></tr>'
             )
 
         footer_links = (
-            f'<a href="{self.escape_html(self._add_utm(self.base_url))}" style="color:#19433c;text-decoration:none;font-weight:500;">Fabric GPS</a>'
+            f'<a href="{self.escape_html(self._add_utm(self.base_url, campaign=utm_campaign))}" style="color:#19433c;text-decoration:none;font-weight:500;">Fabric GPS</a>'
         )
+
+        cadence_period = "the past day" if cadence_label == "Daily" else "the past 7 days"
+        cadence_sub_text = f"{cadence_label.lower()} updates"
 
         return f"""\
 <!DOCTYPE html>
 <html lang=\"en\">
 <head>
 <meta charset=\"UTF-8\">
-<title>Fabric GPS Weekly Update</title>
+<title>Fabric GPS {cadence_label} Update</title>
 <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">
 <style>
 body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,sans-serif; }}
@@ -552,12 +576,13 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
 </head>
 <body style=\"margin:0;padding:0;background:{BODY_BG};\">
 <span style=\"display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;color:transparent;\">{self.escape_html(preheader)}</span>
-<table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"background:{BODY_BG};padding:24px 0;\">\n  <tr>\n    <td align=\"center\" style=\"padding:0 12px;\">\n      <table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"max-width:640px;\">\n        <tr>\n          <td style=\"background:{HERO_GRADIENT};color:#ffffff;border-radius:14px; padding:34px 34px 38px 34px; text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);\">\n            <img src=\"{self.base_url}/static/fabric_gps_logo.png\" alt=\"Fabric GPS\" style=\"height:48px;width:auto;margin-bottom:12px;\" />\n            <h1 style=\"margin:0 0 10px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;\"> Weekly Update</h1>\n            <p style=\"margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);\">Microsoft Fabric roadmap items modified during the past 7 days.</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:28px;\"></td></tr>\n        {summary_html}\n        <tr><td style=\"padding:0;\">{changes_section}</td></tr>\n        <tr>\n          <td>\n            <div style=\"background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px; padding:22px;margin:6px 0 26px 0;box-shadow:{CARD_SHADOW};text-align:center;\">\n              <p style=\"margin:0 0 14px 0;font-size:14px;color:{TEXT_SECONDARY};\">Tune your filters or explore more history on the site.</p>\n              {self._build_button(self._add_utm(self.base_url), "Open Fabric GPS")}\n            </div>\n          </td>\n        </tr>\n        <tr>\n          <td style=\"background:#f8f9fa;border:1px solid {CARD_BORDER};border-radius:10px; padding:18px 20px;text-align:center;font-size:12px;color:{TEXT_SECONDARY}; line-height:1.5;\">\n            <p style=\"margin:0 0 6px 0;\">Sent to {self.escape_html(subscription.email)} — you’re subscribed to weekly updates.</p>\n            <p style=\"margin:0 0 6px 0;\">\n              <a href=\"{self.escape_html(unsubscribe_url)}\" style=\"color:#19433c;text-decoration:none;font-weight:500;\">Unsubscribe</a>&nbsp;|&nbsp;<a href=\"{self.escape_html(preferences_url)}\" style=\"color:#19433c;text-decoration:none;font-weight:500;\">Manage Preferences</a>&nbsp;|&nbsp; Data sourced from Microsoft Fabric Roadmap\n            </p>\n            <p style=\"margin:8px 0 0 0;color:#8a8886;\">{footer_links}</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:30px;\"></td></tr>\n      </table>\n    </td>\n  </tr>\n</table>\n</body>\n</html>\n"""
+<table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"background:{BODY_BG};padding:24px 0;\">\n  <tr>\n    <td align=\"center\" style=\"padding:0 12px;\">\n      <table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"max-width:640px;\">\n        <tr>\n          <td style=\"background:{HERO_GRADIENT};color:#ffffff;border-radius:14px; padding:34px 34px 38px 34px; text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);\">\n            <h1 style=\"margin:0 0 10px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;\">Fabric GPS — {cadence_label} Update</h1>\n            <p style=\"margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);\">Microsoft Fabric roadmap items modified during {cadence_period}.</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:28px;\"></td></tr>\n        {summary_html}\n        <tr><td style=\"padding:0;\">{changes_section}</td></tr>\n        <tr>\n          <td>\n            <div style=\"background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px; padding:22px;margin:6px 0 26px 0;box-shadow:{CARD_SHADOW};text-align:center;\">\n              <p style=\"margin:0 0 14px 0;font-size:14px;color:{TEXT_SECONDARY};\">Tune your filters or explore more history on the site.</p>\n              {self._build_button(self._add_utm(self.base_url, campaign=utm_campaign), "Open Fabric GPS")}\n            </div>\n          </td>\n        </tr>\n        <tr>\n          <td style=\"background:#f8f9fa;border:1px solid {CARD_BORDER};border-radius:10px; padding:18px 20px;text-align:center;font-size:12px;color:{TEXT_SECONDARY}; line-height:1.5;\">\n            <p style=\"margin:0 0 6px 0;\">Sent to {self.escape_html(subscription.email)} — you’re subscribed to {cadence_sub_text}.</p>\n            <p style=\"margin:0 0 6px 0;\">\n              <a href=\"{self.escape_html(unsubscribe_url)}\" style=\"color:#19433c;text-decoration:none;font-weight:500;\">Unsubscribe</a>&nbsp;|&nbsp;<a href=\"{self.escape_html(preferences_url)}\" style=\"color:#19433c;text-decoration:none;font-weight:500;\">Manage Preferences</a>&nbsp;|&nbsp; Data sourced from Microsoft Fabric Roadmap\n            </p>\n            <p style=\"margin:8px 0 0 0;color:#8a8886;\">{footer_links}</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:30px;\"></td></tr>\n      </table>\n    </td>\n  </tr>\n</table>\n</body>\n</html>\n"""
 
     def generate_email_text(self, changes: List[Dict[str, Any]], subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None) -> str:
         """Generate plain text email content from JSON API data"""
-        unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={subscription.unsubscribe_token}")
-        preferences_url = self._add_utm(f"{self.base_url}/preferences?token={subscription.unsubscribe_token}")
+        utm_campaign = "daily-digest" if subscription.email_cadence == "daily" else "weekly-digest"
+        unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={subscription.unsubscribe_token}", campaign=utm_campaign)
+        preferences_url = self._add_utm(f"{self.base_url}/preferences?token={subscription.unsubscribe_token}", campaign=utm_campaign)
         cadence_label = "DAILY" if subscription.email_cadence == "daily" else "WEEKLY"
 
         text_parts = [
@@ -574,8 +599,10 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
                 "",
             ])
 
+        cadence_period_text = "today's" if subscription.email_cadence == "daily" else "this week's"
+
         text_parts.extend([
-            f"This week's Microsoft Fabric roadmap changes ({len(changes)} items):",
+            f"Microsoft Fabric roadmap changes — {cadence_period_text} update ({len(changes)} items):",
             ""
         ])
         
@@ -607,7 +634,7 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
         
         text_parts.extend([
             "-" * 50,
-            f"Visit {self._add_utm(self.base_url)} to explore the full roadmap.",
+            f"Visit {self._add_utm(self.base_url, campaign=utm_campaign)} to explore the full roadmap.",
             "",
             f"Unsubscribe: {unsubscribe_url}",
             f"Manage Preferences: {preferences_url}",
@@ -648,7 +675,7 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
     <a href="{self.escape_html(release_url)}" style="color:#19433c;text-decoration:none;">{self.escape_html(w.get('feature_name', 'Unknown'))}</a>{removed_badge}
   </div>
   <div style="font-size:13px;color:{TEXT_SECONDARY};">{self.escape_html(w.get('product_name', ''))} · {self.escape_html(w.get('release_type', ''))} · {self.escape_html(w.get('release_status', ''))}</div>
-  <div style="font-size:12px;color:{TEXT_SECONDARY};margin-top:4px;">Last modified: {w.get('last_modified', 'Unknown')}</div>
+  <div style="font-size:12px;color:{TEXT_SECONDARY};margin-top:4px;">Last modified: {self.escape_html(w.get('last_modified', 'Unknown'))}</div>
 </div>"""
 
         html_content = f"""<!DOCTYPE html>
@@ -660,7 +687,8 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
   <tr><td align="center" style="padding:0 12px;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:640px;">
       <tr><td style="background:{HERO_GRADIENT};color:#ffffff;border-radius:14px;padding:30px 34px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
-        <h1 style="margin:0 0 8px 0;font-size:24px;font-weight:600;">🔔 Feature Watch Alert</h1>
+        <h1 style="margin:0 0 8px 0;font-size:24px;font-weight:600;">Fabric GPS</h1>
+        <p style="margin:0 0 4px 0;font-size:16px;font-weight:600;">Feature Watch Alert</p>
         <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.9);">Features you're watching have been updated.</p>
       </td></tr>
       <tr><td style="height:24px;"></td></tr>
@@ -707,7 +735,7 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
     def send_azure_email(self, to_email: str, subject: str, html_content: str, text_content: str, unsubscribe_token: str) -> bool:
         """Send an email using Azure Communication Services"""
         try:
-            unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={unsubscribe_token}")
+            unsubscribe_url = f"{self.base_url}/unsubscribe?token={unsubscribe_token}"
             
             message = {
                 "senderAddress": self.from_email,
@@ -752,6 +780,7 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
         - Expired verification records (expires_at < now or is_used True)
         - Used verification records (is_used = True)
         - Stale unverified subscriptions (verification_token not null, is_verified False, created_at older than 24h)
+        - Old email content cache entries (older than 2 days)
         Returns dict of counts removed.
         """
         from sqlalchemy.orm import sessionmaker
@@ -759,7 +788,7 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
         SessionLocal = sessionmaker(bind=engine, future=True)
         now = datetime.utcnow()
         threshold = now - timedelta(hours=24)
-        counts = {"expired_or_used_verifications": 0, "stale_unverified": 0}
+        counts = {"expired_or_used_verifications": 0, "stale_unverified": 0, "old_cache_entries": 0}
         with SessionLocal() as session:
             # Expired or used verifications
             expired_stmt = delete(EmailVerificationModel).where(
@@ -778,6 +807,14 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
             )
             result_stale = session.execute(stale_stmt)
             counts["stale_unverified"] = result_stale.rowcount or 0
+
+            # Old cache entries (keep last 2 days)
+            old_date = (now - timedelta(days=2)).strftime('%Y-%m-%d')
+            cache_stmt = delete(EmailContentCacheModel).where(
+                EmailContentCacheModel.cache_date < old_date
+            )
+            result_cache = session.execute(cache_stmt)
+            counts["old_cache_entries"] = result_cache.rowcount or 0
 
             session.commit()
         return counts

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -24,7 +24,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from db.db_sqlserver import (
     make_engine, get_unsent_active_subscriptions, EmailSubscriptionModel,
-    EmailVerificationModel, EmailContentCacheModel
+    EmailVerificationModel, EmailContentCacheModel,
+    get_digest_eligible_subscriptions, get_subscriptions_with_changed_watches,
+    update_watch_hashes,
 )
 
 try:
@@ -139,46 +141,71 @@ class WeeklyEmailSender:
 
         return all_changes, ai_summary
 
-    def send_weekly_emails(self):
-        """Send weekly emails to all active subscribers"""
+    def send_emails(self):
+        """Send digest and watch alert emails to eligible subscribers."""
         try:
             engine = make_engine()
-            subscriptions = get_unsent_active_subscriptions(engine, 7)
-            
-            logger.info(f"Found {len(subscriptions)} active subscriptions")
 
-            if not subscriptions:
-                logger.info("No subscriptions to process, exiting")
-                return
+            # --- Digest queue: daily/weekly subscribers whose interval elapsed ---
+            subscriptions = get_digest_eligible_subscriptions(engine)
+            logger.info(f"Digest queue: {len(subscriptions)} eligible subscriptions")
 
             # Load or generate email content (cached for 24h so all
             # hourly batches use the same data)
             all_changes, ai_summary = self._load_or_generate_content()
-            
+
             sent_count = 0
             error_count = 0
             # Azure Communication Services quota: 30 emails/minute
             MIN_SEND_INTERVAL = 2.0  # seconds between sends (60/30)
             last_send_time = 0.0
-            
+
             for subscription in subscriptions:
                 try:
-                    # Throttle to stay within send quota
                     elapsed = time.monotonic() - last_send_time
                     if elapsed < MIN_SEND_INTERVAL:
                         time.sleep(MIN_SEND_INTERVAL - elapsed)
 
-                    if self.send_weekly_email(subscription, ai_summary=ai_summary):
+                    if self.send_digest_email(subscription, ai_summary=ai_summary):
                         sent_count += 1
                         last_send_time = time.monotonic()
                         self.update_last_email_sent(subscription.id)
                     else:
                         error_count += 1
                 except Exception as e:
-                    logger.error(f"Error sending email to {subscription.email}: {e}")
+                    logger.error(f"Error sending digest to {subscription.email}: {e}")
                     error_count += 1
-            
-            logger.info(f"Weekly email job completed. Sent: {sent_count}, Errors: {error_count}")
+
+            logger.info(f"Digest queue completed. Sent: {sent_count}, Errors: {error_count}")
+
+            # --- Watch alert queue: all subscribers with changed watches ---
+            watch_sent = 0
+            watch_errors = 0
+            try:
+                watch_results = get_subscriptions_with_changed_watches(engine)
+                logger.info(f"Watch alert queue: {len(watch_results)} subscribers with changed watches")
+
+                for sub, changed_watches in watch_results:
+                    try:
+                        elapsed = time.monotonic() - last_send_time
+                        if elapsed < MIN_SEND_INTERVAL:
+                            time.sleep(MIN_SEND_INTERVAL - elapsed)
+
+                        if self.send_watch_alert_email(sub, changed_watches):
+                            watch_sent += 1
+                            last_send_time = time.monotonic()
+                            hash_updates = [(w['watch_id'], w['current_hash']) for w in changed_watches]
+                            update_watch_hashes(engine, hash_updates)
+                        else:
+                            watch_errors += 1
+                    except Exception as e:
+                        logger.error(f"Error sending watch alert to {sub.email}: {e}")
+                        watch_errors += 1
+
+                logger.info(f"Watch alert queue completed. Sent: {watch_sent}, Errors: {watch_errors}")
+            except Exception as e:
+                logger.error(f"Error processing watch alerts: {e}")
+
             # Run cleanup after sending
             try:
                 cleanup_counts = self.cleanup_expired(engine)
@@ -189,13 +216,16 @@ class WeeklyEmailSender:
                 )
             except Exception as cleanup_exc:
                 logger.error(f"Cleanup step failed: {cleanup_exc}")
-            
+
         except Exception as e:
-            logger.error(f"Fatal error in weekly email job: {e}")
+            logger.error(f"Fatal error in email job: {e}")
             raise
 
-    def send_weekly_email(self, subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None) -> bool:
-        """Send weekly email to a single subscriber using JSON API"""
+    # Keep old name as alias for backward compatibility
+    send_weekly_emails = send_emails
+
+    def send_digest_email(self, subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None) -> bool:
+        """Send a digest email to a single subscriber."""
         try:
             # Get changes using JSON API with subscriber's filters
             changes = self.get_changes_from_api(subscription)
@@ -205,7 +235,8 @@ class WeeklyEmailSender:
                 return True
             
             # Generate email content
-            subject = f"Fabric GPS Weekly Update - {len(changes)} Changes"
+            cadence_label = "Daily" if subscription.email_cadence == "daily" else "Weekly"
+            subject = f"Fabric GPS {cadence_label} Update - {len(changes)} Changes"
             html_content = self.generate_email_html(changes, subscription, ai_summary=ai_summary)
             text_content = self.generate_email_text(changes, subscription, ai_summary=ai_summary)
             
@@ -433,6 +464,7 @@ class WeeklyEmailSender:
     def generate_email_html(self, changes: List[Dict[str, Any]], subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None) -> str:
         """Generate HTML email content styled to match index page design."""
         unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={subscription.unsubscribe_token}")
+        preferences_url = self._add_utm(f"{self.base_url}/preferences?token={subscription.unsubscribe_token}")
 
         # Style tokens (aligned with site)
         BODY_BG = "#f3f2f1"
@@ -520,14 +552,16 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
 </head>
 <body style=\"margin:0;padding:0;background:{BODY_BG};\">
 <span style=\"display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;color:transparent;\">{self.escape_html(preheader)}</span>
-<table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"background:{BODY_BG};padding:24px 0;\">\n  <tr>\n    <td align=\"center\" style=\"padding:0 12px;\">\n      <table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"max-width:640px;\">\n        <tr>\n          <td style=\"background:{HERO_GRADIENT};color:#ffffff;border-radius:14px; padding:34px 34px 38px 34px; text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);\">\n            <img src=\"{self.base_url}/static/fabric_gps_logo.png\" alt=\"Fabric GPS\" style=\"height:48px;width:auto;margin-bottom:12px;\" />\n            <h1 style=\"margin:0 0 10px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;\"> Weekly Update</h1>\n            <p style=\"margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);\">Microsoft Fabric roadmap items modified during the past 7 days.</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:28px;\"></td></tr>\n        {summary_html}\n        <tr><td style=\"padding:0;\">{changes_section}</td></tr>\n        <tr>\n          <td>\n            <div style=\"background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px; padding:22px;margin:6px 0 26px 0;box-shadow:{CARD_SHADOW};text-align:center;\">\n              <p style=\"margin:0 0 14px 0;font-size:14px;color:{TEXT_SECONDARY};\">Tune your filters or explore more history on the site.</p>\n              {self._build_button(self._add_utm(self.base_url), "Open Fabric GPS")}\n            </div>\n          </td>\n        </tr>\n        <tr>\n          <td style=\"background:#f8f9fa;border:1px solid {CARD_BORDER};border-radius:10px; padding:18px 20px;text-align:center;font-size:12px;color:{TEXT_SECONDARY}; line-height:1.5;\">\n            <p style=\"margin:0 0 6px 0;\">Sent to {self.escape_html(subscription.email)} — you’re subscribed to weekly updates.</p>\n            <p style=\"margin:0 0 6px 0;\">\n              <a href=\"{self.escape_html(unsubscribe_url)}\" style=\"color:#19433c;text-decoration:none;font-weight:500;\">Unsubscribe</a>&nbsp;|&nbsp; Data sourced from Microsoft Fabric Roadmap\n            </p>\n            <p style=\"margin:8px 0 0 0;color:#8a8886;\">{footer_links}</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:30px;\"></td></tr>\n      </table>\n    </td>\n  </tr>\n</table>\n</body>\n</html>\n"""
+<table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"background:{BODY_BG};padding:24px 0;\">\n  <tr>\n    <td align=\"center\" style=\"padding:0 12px;\">\n      <table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"max-width:640px;\">\n        <tr>\n          <td style=\"background:{HERO_GRADIENT};color:#ffffff;border-radius:14px; padding:34px 34px 38px 34px; text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);\">\n            <img src=\"{self.base_url}/static/fabric_gps_logo.png\" alt=\"Fabric GPS\" style=\"height:48px;width:auto;margin-bottom:12px;\" />\n            <h1 style=\"margin:0 0 10px 0;font-size:26px;line-height:1.2;font-weight:600;letter-spacing:.5px;\"> Weekly Update</h1>\n            <p style=\"margin:0;font-size:15px;line-height:1.5;max-width:520px;display:inline-block;color:rgba(255,255,255,0.95);\">Microsoft Fabric roadmap items modified during the past 7 days.</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:28px;\"></td></tr>\n        {summary_html}\n        <tr><td style=\"padding:0;\">{changes_section}</td></tr>\n        <tr>\n          <td>\n            <div style=\"background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px; padding:22px;margin:6px 0 26px 0;box-shadow:{CARD_SHADOW};text-align:center;\">\n              <p style=\"margin:0 0 14px 0;font-size:14px;color:{TEXT_SECONDARY};\">Tune your filters or explore more history on the site.</p>\n              {self._build_button(self._add_utm(self.base_url), "Open Fabric GPS")}\n            </div>\n          </td>\n        </tr>\n        <tr>\n          <td style=\"background:#f8f9fa;border:1px solid {CARD_BORDER};border-radius:10px; padding:18px 20px;text-align:center;font-size:12px;color:{TEXT_SECONDARY}; line-height:1.5;\">\n            <p style=\"margin:0 0 6px 0;\">Sent to {self.escape_html(subscription.email)} — you’re subscribed to weekly updates.</p>\n            <p style=\"margin:0 0 6px 0;\">\n              <a href=\"{self.escape_html(unsubscribe_url)}\" style=\"color:#19433c;text-decoration:none;font-weight:500;\">Unsubscribe</a>&nbsp;|&nbsp;<a href=\"{self.escape_html(preferences_url)}\" style=\"color:#19433c;text-decoration:none;font-weight:500;\">Manage Preferences</a>&nbsp;|&nbsp; Data sourced from Microsoft Fabric Roadmap\n            </p>\n            <p style=\"margin:8px 0 0 0;color:#8a8886;\">{footer_links}</p>\n          </td>\n        </tr>\n        <tr><td style=\"height:30px;\"></td></tr>\n      </table>\n    </td>\n  </tr>\n</table>\n</body>\n</html>\n"""
 
     def generate_email_text(self, changes: List[Dict[str, Any]], subscription: EmailSubscriptionModel, ai_summary: Optional[str] = None) -> str:
         """Generate plain text email content from JSON API data"""
         unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={subscription.unsubscribe_token}")
+        preferences_url = self._add_utm(f"{self.base_url}/preferences?token={subscription.unsubscribe_token}")
+        cadence_label = "DAILY" if subscription.email_cadence == "daily" else "WEEKLY"
 
         text_parts = [
-            "FABRIC GPS - WEEKLY UPDATE",
+            f"FABRIC GPS - {cadence_label} UPDATE",
             "=" * 50,
             "",
         ]
@@ -576,10 +610,99 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
             f"Visit {self._add_utm(self.base_url)} to explore the full roadmap.",
             "",
             f"Unsubscribe: {unsubscribe_url}",
+            f"Manage Preferences: {preferences_url}",
             "Data sourced from Microsoft Fabric Roadmap"
         ])
         
         return "\n".join(text_parts)
+
+    def send_watch_alert_email(self, subscription: EmailSubscriptionModel, changed_watches: List[Dict[str, Any]]) -> bool:
+        """Send a watch alert email for changed watched features."""
+        if not changed_watches:
+            return True
+
+        unsubscribe_url = self._add_utm(f"{self.base_url}/unsubscribe?token={subscription.unsubscribe_token}")
+        preferences_url = self._add_utm(f"{self.base_url}/preferences?token={subscription.unsubscribe_token}")
+
+        if len(changed_watches) == 1:
+            subject = f"Fabric GPS Alert: {changed_watches[0]['feature_name']} Updated"
+        else:
+            subject = f"Fabric GPS Alert: {len(changed_watches)} Watched Features Updated"
+
+        # Build HTML
+        BODY_BG = "#f3f2f1"
+        CARD_BG = "#ffffff"
+        CARD_BORDER = "#e1e5e9"
+        CARD_SHADOW = "0 1px 2px rgba(0,0,0,0.04),0 4px 10px rgba(0,0,0,0.06)"
+        TEXT_SECONDARY = "#605e5c"
+        HERO_GRADIENT = "linear-gradient(135deg,#19433c 0%,#286c61 100%)"
+        ALERT_BG = "#fff4ce"
+        ALERT_BORDER = "#f0c800"
+
+        items_html = ""
+        for w in changed_watches:
+            release_url = self._add_utm(f"{self.base_url}/release/{w['release_item_id']}", campaign='watch-alert')
+            removed_badge = ' <span style="background:#d13438;color:#fff;padding:2px 8px;border-radius:4px;font-size:11px;">REMOVED</span>' if w.get('active') is False else ''
+            items_html += f"""<div style="background:{CARD_BG};border:1px solid {CARD_BORDER};border-radius:10px;padding:18px 20px;margin-bottom:12px;box-shadow:{CARD_SHADOW};">
+  <div style="font-weight:600;font-size:15px;color:#323130;margin-bottom:6px;">
+    <a href="{self.escape_html(release_url)}" style="color:#19433c;text-decoration:none;">{self.escape_html(w.get('feature_name', 'Unknown'))}</a>{removed_badge}
+  </div>
+  <div style="font-size:13px;color:{TEXT_SECONDARY};">{self.escape_html(w.get('product_name', ''))} · {self.escape_html(w.get('release_type', ''))} · {self.escape_html(w.get('release_status', ''))}</div>
+  <div style="font-size:12px;color:{TEXT_SECONDARY};margin-top:4px;">Last modified: {w.get('last_modified', 'Unknown')}</div>
+</div>"""
+
+        html_content = f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Fabric GPS Watch Alert</title>
+<style>body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,sans-serif; }}</style>
+</head><body style="margin:0;padding:0;background:{BODY_BG};">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:{BODY_BG};padding:24px 0;">
+  <tr><td align="center" style="padding:0 12px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:640px;">
+      <tr><td style="background:{HERO_GRADIENT};color:#ffffff;border-radius:14px;padding:30px 34px;text-align:center;box-shadow:0 4px 14px rgba(0,0,0,0.12);">
+        <h1 style="margin:0 0 8px 0;font-size:24px;font-weight:600;">🔔 Feature Watch Alert</h1>
+        <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.9);">Features you're watching have been updated.</p>
+      </td></tr>
+      <tr><td style="height:24px;"></td></tr>
+      <tr><td style="padding:0;">{items_html}</td></tr>
+      <tr><td style="height:12px;"></td></tr>
+      <tr><td style="background:#f8f9fa;border:1px solid {CARD_BORDER};border-radius:10px;padding:18px 20px;text-align:center;font-size:12px;color:{TEXT_SECONDARY};line-height:1.5;">
+        <p style="margin:0 0 6px 0;">Sent to {self.escape_html(subscription.email)}</p>
+        <p style="margin:0 0 6px 0;">
+          <a href="{self.escape_html(preferences_url)}" style="color:#19433c;text-decoration:none;font-weight:500;">Manage Watches</a>&nbsp;|&nbsp;
+          <a href="{self.escape_html(unsubscribe_url)}" style="color:#19433c;text-decoration:none;font-weight:500;">Unsubscribe</a>
+        </p>
+      </td></tr>
+      <tr><td style="height:30px;"></td></tr>
+    </table>
+  </td></tr>
+</table></body></html>"""
+
+        # Plain text
+        text_parts = ["FABRIC GPS - FEATURE WATCH ALERT", "=" * 50, ""]
+        for w in changed_watches:
+            removed = " [REMOVED]" if w.get('active') is False else ""
+            text_parts.extend([
+                f"• {w.get('feature_name', 'Unknown')}{removed}",
+                f"  Product: {w.get('product_name', '')}",
+                f"  Status: {w.get('release_status', '')}",
+                f"  Link: {self.base_url}/release/{w['release_item_id']}",
+                "",
+            ])
+        text_parts.extend([
+            "-" * 50,
+            f"Manage Watches: {preferences_url}",
+            f"Unsubscribe: {unsubscribe_url}",
+        ])
+        text_content = "\n".join(text_parts)
+
+        return self.send_azure_email(
+            to_email=subscription.email,
+            subject=subject,
+            html_content=html_content,
+            text_content=text_content,
+            unsubscribe_token=subscription.unsubscribe_token
+        )
 
     def send_azure_email(self, to_email: str, subject: str, html_content: str, text_content: str, unsubscribe_token: str) -> bool:
         """Send an email using Azure Communication Services"""
@@ -661,14 +784,14 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
 
 
 def main():
-    """Main function to run the weekly email job"""
+    """Main function to run the email job (digest + watch alerts)."""
     try:
-        logger.info("Starting weekly email job")
+        logger.info("Starting email job")
         sender = WeeklyEmailSender()
-        sender.send_weekly_emails()
-        logger.info("Weekly email job completed successfully")
+        sender.send_emails()
+        logger.info("Email job completed successfully")
     except Exception as e:
-        logger.error(f"Weekly email job failed: {e}")
+        logger.error(f"Email job failed: {e}")
         sys.exit(1)
 
 

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -11,6 +11,7 @@ import os
 import sys
 import json
 import time
+import hashlib
 import requests
 import logging
 from datetime import datetime, timedelta
@@ -73,6 +74,8 @@ class WeeklyEmailSender:
 
         # In-memory cache for raw 7-day data (populated once per run)
         self._raw_changes = None
+        # Engine shared across the current job run (set by send_emails)
+        self._engine = None
 
     @staticmethod
     def _add_utm(url: str, source: str = 'email', medium: str = 'email',
@@ -95,14 +98,19 @@ class WeeklyEmailSender:
 
     @staticmethod
     def _build_cache_key(subscription: EmailSubscriptionModel) -> str:
-        """Build a deterministic cache key from subscriber cadence + filters."""
+        """Build a deterministic, collision-free cache key from subscriber cadence + filters.
+
+        Uses SHA-256 of the full key string to avoid truncation collisions when
+        subscribers have long filter lists.
+        """
         parts = [
             subscription.email_cadence or 'weekly',
             (subscription.product_filter or '').strip().lower(),
             (subscription.release_type_filter or '').strip().lower(),
             (subscription.release_status_filter or '').strip().lower(),
         ]
-        return '|'.join(parts)[:255]
+        raw = '|'.join(parts)
+        return hashlib.sha256(raw.encode()).hexdigest()
 
     def _get_subscriber_content(self, subscription: EmailSubscriptionModel):
         """Return (changes, ai_summary) for a subscriber, using per-date per-filter DB cache.
@@ -119,7 +127,7 @@ class WeeklyEmailSender:
         cache_key = self._build_cache_key(subscription)
         cache_date = datetime.utcnow().strftime('%Y-%m-%d')
 
-        engine = make_engine()
+        engine = self._engine or make_engine()
         SessionLocal = sessionmaker(bind=engine, future=True)
 
         # Try DB cache
@@ -202,6 +210,7 @@ class WeeklyEmailSender:
         """Send digest and watch alert emails to eligible subscribers."""
         try:
             engine = make_engine()
+            self._engine = engine  # share engine across _get_subscriber_content calls
 
             # --- Digest queue: daily/weekly subscribers whose interval elapsed ---
             subscriptions = get_digest_eligible_subscriptions(engine)


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the email subscription system covering correctness, design consistency, and new user-facing features.

### Bug Fixes
- **Date formatting** - fmt_date() was truncating dates; now uses fromisoformat()
- **Daily cadence filtering** - Daily subscribers were getting the full 7-day window; now properly filters to last 24 hours
- **Date vs DateTime gating** - last_email_sent upgraded from DATE to DATETIME2 to prevent premature re-eligibility after midnight
- **AI summary scope** - No longer shows unfiltered weekly summary to daily/filtered subscribers
- **Plain text copy** - Fixed hardcoded 'This week' text for daily subscribers
- **FK type mismatch** - feature_watches migration used NVARCHAR but referenced VARCHAR columns
- **Detached session** - verify_email_subscription accessed subscription.id after session close
- **Preferences save** - Token wasn't extracted from JSON body on POST requests
- **Unescaped HTML** - last_modified in watch alerts was injected raw

### Email Design
- **Cadence-aware content** - Subject, hero, subtitle, footer, preheader all adapt to daily/weekly
- **UTM campaigns** - daily-digest vs weekly-digest (and clean URL in List-Unsubscribe header)
- **Card cap** - Max 20 cards with filtered View All overflow link matching subscriber preferences
- **Verification emails** - Context-specific copy for weekly, daily, and feature watch flows
- **White text headers** - Replaced PNG logo and emoji with clean white text on gradient

### Content Caching Redesign
- Cache keyed by (date, cadence|product|type|status) instead of single global row
- AI summary generated per filter combo (always relevant to subscriber changes)
- Same-key subscribers get identical emails all day
- Old cache entries auto-cleaned after 2 days

### New Features
- **Manage subscription from website** - Already subscribed? section on /subscribe sends a preferences link email
- **POST /api/send-preferences-link** - Always returns 200 (no email enumeration)
- **Monday-only weekly digests** - Weekly cadence skipped on non-Monday runs
- **/dev/email-preview** - Development-only preview harness for all 7 email types

### Design System
- All email pages restyled to match the main site design language
- Added shared CSS components: .page-card, .form-input, .radio-group, .watch-list, .btn-remove, etc.
- Consistent use of .button/.button-primary (removed old .btn class)

### Migrations
1. upgrade_last_email_sent - DATE to DATETIME2
2. rebuild_email_content_cache - Drop singleton, recreate with (cache_date, cache_key) composite key
3. add_cadence_and_watches - Fixed NVARCHAR to VARCHAR for FK compatibility

### Files Changed
12 files, +1196 / -416 lines
