### PR TITLE
Fix: Stamp watch hash on creation to prevent spurious alerts

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -1127,9 +1127,17 @@ def add_feature_watch(engine, subscription_id: str, release_item_id: str) -> boo
             )
             if existing:
                 return False
+            # Stamp the current row_hash so the subscriber isn't immediately
+            # alerted for a feature that hasn't changed since they subscribed.
+            current_hash = session.scalar(
+                select(ReleaseItemModel.row_hash).where(
+                    ReleaseItemModel.release_item_id == release_item_id
+                )
+            )
             session.add(FeatureWatchModel(
                 subscription_id=subscription_id,
                 release_item_id=release_item_id,
+                last_notified_hash=current_hash,
             ))
     return True
 


### PR DESCRIPTION
When a user adds a feature watch, \last_notified_hash\ was left as \NULL\. The email job treated \NULL\ as a change, sending an alert for features that hadn't actually been modified.

This fix looks up the release item's current \ow_hash\ at watch creation time and stamps it on the new \FeatureWatchModel\, so alerts only fire when content genuinely changes after the user subscribed.