### PR TITLE
Combine email and fetch into a single refresh container

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,11 +2,10 @@
 
 ## Architecture
 
-Fabric GPS is a Python/Flask application that tracks Microsoft Fabric roadmap releases and matches them with related blog posts using vector embeddings. It runs as a single Docker image with three operational modes controlled by the `APP_MODE` environment variable:
+Fabric GPS is a Python/Flask application that tracks Microsoft Fabric roadmap releases and matches them with related blog posts using vector embeddings. It runs as a single Docker image with two operational modes controlled by the `APP_MODE` environment variable:
 
 - **`web`** — Flask app served via Gunicorn (`server.py`). Exposes an RSS 2.0 feed, a REST API (`/api/releases`), HTML pages, and email subscription management endpoints.
-- **`fetch`** — Data pipeline that runs sequentially: `get_current_releases.py` → `scrape_fabric_blog.py --rss` → `vectorize_blog_posts.py` → `match_releases_to_blogs.py`. Scrapes the Fabric roadmap and blog, generates Azure OpenAI embeddings (`text-embedding-3-small`), and matches releases to blog posts via SQL Server `VECTOR_DISTANCE('cosine', ...)`.
-- **`email`** — Weekly batch job (`weekly_email_job.py`) that sends personalized digest emails to verified subscribers via Azure Communication Services.
+- **`refresh`** — Hourly batch job that runs the data pipeline followed by the email sender, sequentially: `get_current_releases.py` → `scrape_fabric_blog.py --rss` → `vectorize_blog_posts.py` → `match_releases_to_blogs.py` → `weekly_email_job.py`. Scrapes the Fabric roadmap and blog, generates Azure OpenAI embeddings (`text-embedding-3-small`), matches releases to blog posts via SQL Server `VECTOR_DISTANCE('cosine', ...)`, and then sends digest and watch-alert emails to verified subscribers via Azure Communication Services.
 
 ### Key data flow
 
@@ -45,8 +44,8 @@ gunicorn -c gunicorn.conf.py
 docker build -t fabric-gps .
 docker run -e APP_MODE=web -e SQLSERVER_CONN="..." -p 8000:8000 fabric-gps
 
-# Run the data fetch pipeline
-APP_MODE=fetch bash start.sh
+# Run the data refresh + email pipeline
+APP_MODE=refresh bash start.sh
 
 # Run a single pipeline step
 python get_current_releases.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ ENV APP_MODE=web \
 
 EXPOSE 8000
 
-# Entrypoint dispatches based on APP_MODE (web | fetch)
+# Entrypoint dispatches based on APP_MODE (web | refresh)
 CMD ["bash", "start.sh"]

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Existing subscribers can manage their preferences at `/preferences?token=<unsubs
 
 ### Scheduling
 
-The email job (`APP_MODE=email`) should be scheduled to run **hourly**. It handles both cadences internally:
+The refresh job (`APP_MODE=refresh`) runs the data fetch pipeline (roadmap, blog scrape, vectorization, matching) followed by the email send job. It should be scheduled to run **hourly**. The email step handles both cadences internally:
 - Digest emails are sent when each subscriber's cadence interval has elapsed
 - Feature watch alerts are checked every run
 
 ```bash
 # Example cron (every hour at minute 0)
-0 * * * * docker run --rm -e APP_MODE=email -e SQLSERVER_CONN="..." fabric-gps
+0 * * * * docker run --rm -e APP_MODE=refresh -e SQLSERVER_CONN="..." fabric-gps
 ```
 
 ## Caching

--- a/start.sh
+++ b/start.sh
@@ -8,13 +8,14 @@ alembic upgrade head
 if [[ "$MODE" == "web" ]]; then
   # Run the Flask app with Gunicorn
   exec gunicorn -c gunicorn.conf.py
-elif [[ "$MODE" == "fetch" ]]; then
-  # Run the data fetcher scripts
-  python get_current_releases.py && python scrape_fabric_blog.py --rss && python vectorize_blog_posts.py && exec python match_releases_to_blogs.py
-elif [[ "$MODE" == "email" ]]; then
-  # Run the email sending script
-  exec python weekly_email_job.py
+elif [[ "$MODE" == "refresh" ]]; then
+  # Run the data fetcher pipeline followed by the email sending job
+  python get_current_releases.py \
+    && python scrape_fabric_blog.py --rss \
+    && python vectorize_blog_posts.py \
+    && python match_releases_to_blogs.py \
+    && exec python weekly_email_job.py
 else
-  echo "Unknown APP_MODE: $MODE (expected 'web', 'fetch', or 'email')" >&2
+  echo "Unknown APP_MODE: $MODE (expected 'web' or 'refresh')" >&2
   exit 1
 fi


### PR DESCRIPTION
Replaces the separate `APP_MODE=fetch` and `APP_MODE=email` container modes with a unified `APP_MODE=refresh` that runs the full data pipeline followed by the email job in a single invocation.

### Changes
- `start.sh`: removed the `fetch` and `email` branches; added a `refresh` branch that chains `get_current_releases.py` → `scrape_fabric_blog.py --rss` → `vectorize_blog_posts.py` → `match_releases_to_blogs.py` → `weekly_email_job.py`. Dropped the stray `exec` on `match_releases_to_blogs.py` (it would have replaced the shell process and skipped the email step).
- `Dockerfile`: updated the entrypoint comment.
- `README.md`: updated the scheduling section to reference `APP_MODE=refresh`.
- `.github/copilot-instructions.md`: updated architecture and build sections to describe two modes (`web` and `refresh`).

### Deployment note
Existing schedules using `APP_MODE=fetch` or `APP_MODE=email` will need to be updated to `APP_MODE=refresh` (run hourly).
