### PR TITLE
Security audit remediations: tokens, rate limits, headers, HTTPS

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -8,6 +8,7 @@ from typing import Iterable, Any, Tuple, Dict
 import urllib.parse
 import time
 import random
+import secrets
 import logging
 
 # ...existing code...
@@ -804,8 +805,48 @@ def get_changelog_with_changes(
 
 
 def generate_secure_token() -> str:
-    """Generate a secure random token for email verification/unsubscribe"""
-    return hashlib.sha256(f"{uuid.uuid4()}{time.time()}{random.random()}".encode()).hexdigest()
+    """Generate a cryptographically secure random token for email verification/unsubscribe.
+
+    Returns a 64-character URL-safe base64 string from `secrets.token_urlsafe(48)`.
+    Fits in the existing String(64) token columns.
+    """
+    return secrets.token_urlsafe(48)
+
+
+class EmailRateLimitExceeded(Exception):
+    """Raised when an email address has requested too many verifications recently."""
+    pass
+
+
+# Per-email cap on verification emails (subscribe + watch combined). Pairs with
+# the per-IP rate limits in server.py to mitigate proxy-rotation email bombing.
+_EMAIL_VERIFICATION_HOURLY_CAP = 5
+
+
+def _enforce_email_verification_quota(session, email: str) -> None:
+    """Raise EmailRateLimitExceeded if `email` has hit the hourly verification cap.
+
+    Counts EmailVerificationModel rows created in the last hour for this address.
+    Must be called inside an active SQLAlchemy session before the new verification
+    row is added.
+
+    Note: this is a *soft* cap. The count-then-insert sequence is not atomic, so
+    a burst of concurrent requests for the same email can let a few extra
+    verifications through. That's acceptable — the goal is to prevent
+    thousands-of-emails abuse, not to enforce an exact per-hour count. Per-IP
+    rate limits in server.py provide an additional layer of defense.
+    """
+    cutoff = datetime.utcnow() - timedelta(hours=1)
+    recent = session.scalar(
+        select(func.count())
+        .select_from(EmailVerificationModel)
+        .where(EmailVerificationModel.email == email)
+        .where(EmailVerificationModel.created_at >= cutoff)
+    ) or 0
+    if recent >= _EMAIL_VERIFICATION_HOURLY_CAP:
+        raise EmailRateLimitExceeded(
+            f"Too many verification requests for {email} in the last hour"
+        )
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
@@ -814,6 +855,8 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
 
     Returns tuple of (subscription_id, verification_token).
     An empty verification_token means the user is already verified.
+
+    Raises EmailRateLimitExceeded if the email has hit the hourly verification cap.
     """
     if cadence not in ('daily', 'weekly'):
         cadence = 'weekly'
@@ -828,7 +871,9 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
         if existing and existing.is_verified:
             # Already subscribed and verified
             return existing.id, ""
-        
+
+        _enforce_email_verification_quota(session, email)
+
         verification_token = generate_secure_token()
         unsubscribe_token = generate_secure_token()
         
@@ -882,10 +927,14 @@ def create_watch_verification(engine, email: str, release_item_id: str) -> Tuple
 
     Returns (subscription_id, verification_token). The watch is only added
     when the user verifies via the token.
+
+    Raises EmailRateLimitExceeded if the email has hit the hourly verification cap.
     """
     SessionLocal = sessionmaker(bind=engine, future=True)
 
     with SessionLocal() as session:
+        _enforce_email_verification_quota(session, email)
+
         existing = session.scalar(
             select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == email)
         )

--- a/migrations/versions/add_email_verification_rate_limit_index.py
+++ b/migrations/versions/add_email_verification_rate_limit_index.py
@@ -1,0 +1,44 @@
+"""add composite index on email_verifications(email, created_at) for rate-limit query
+
+Revision ID: add_email_verif_rate_idx
+Revises: rebuild_email_content_cache
+Create Date: 2026-04-20 14:20:00.000000
+"""
+from alembic import op
+
+
+revision = 'add_email_verif_rate_idx'
+down_revision = 'rebuild_email_content_cache'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Supports the per-email hourly verification quota query in
+    # db.db_sqlserver._enforce_email_verification_quota, which filters on
+    # (email == :email AND created_at >= :cutoff). The existing single-column
+    # index on `email` would still scan all rows for a given address.
+    op.execute("""
+        IF NOT EXISTS (
+            SELECT 1 FROM sys.indexes
+            WHERE name = 'ix_email_verifications_email_created_at'
+              AND object_id = OBJECT_ID('email_verifications')
+        )
+        BEGIN
+            CREATE INDEX ix_email_verifications_email_created_at
+                ON email_verifications (email, created_at)
+        END
+    """)
+
+
+def downgrade():
+    op.execute("""
+        IF EXISTS (
+            SELECT 1 FROM sys.indexes
+            WHERE name = 'ix_email_verifications_email_created_at'
+              AND object_id = OBJECT_ID('email_verifications')
+        )
+        BEGIN
+            DROP INDEX ix_email_verifications_email_created_at ON email_verifications
+        END
+    """)

--- a/server.py
+++ b/server.py
@@ -42,6 +42,7 @@ from db.db_sqlserver import (
     get_verified_subscription_by_email,
     add_feature_watch, remove_feature_watch, get_feature_watches_for_subscription,
     create_watch_verification, get_release_item_by_id,
+    EmailRateLimitExceeded,
 )
 from lib.embeddings import get_embedding, is_available as embeddings_available
 
@@ -91,8 +92,15 @@ FROM_EMAIL = os.getenv('FROM_EMAIL', 'noreply@yourdomain.com')
 FROM_NAME = os.getenv('FROM_NAME', 'Fabric GPS')
 BASE_URL = os.getenv('BASE_URL', 'http://localhost:8000')
 ASYNC_EMAIL_VERIFICATION = os.getenv('ASYNC_EMAIL_VERIFICATION', '1') != '0'
-# ACS resource ID for validating Event Grid webhook events
+# ACS resource ID for validating Event Grid webhook events. Required in non-dev
+# so the /webhooks/email-events endpoint can reject events from unknown topics
+# instead of silently accepting any caller's bounce data.
 ACS_RESOURCE_ID = os.getenv('ACS_RESOURCE_ID', '')
+if os.getenv("CURRENT_ENVIRONMENT") != "development" and not ACS_RESOURCE_ID:
+    raise RuntimeError(
+        "ACS_RESOURCE_ID must be set in production so the email events webhook "
+        "can validate the Event Grid topic."
+    )
 
 
 CANONICAL_HOST = os.getenv('CANONICAL_HOST', '')
@@ -100,6 +108,14 @@ REDIRECT_HOSTS = {h.strip() for h in os.getenv('REDIRECT_HOSTS', '').split(',') 
 
 # Use canonical host for email URLs if configured, otherwise fall back to BASE_URL
 EMAIL_BASE_URL = f"https://{CANONICAL_HOST}" if CANONICAL_HOST else BASE_URL
+
+# Enforce HTTPS for outbound email URLs in non-development environments. Tokens
+# embedded in these links must not be transmitted over cleartext HTTP.
+if os.getenv("CURRENT_ENVIRONMENT") != "development" and not EMAIL_BASE_URL.startswith("https://"):
+    raise RuntimeError(
+        f"EMAIL_BASE_URL must use HTTPS in production (got {EMAIL_BASE_URL!r}). "
+        "Set CANONICAL_HOST or BASE_URL to an https:// URL."
+    )
 
 _NO_CACHE_PATHS = ("/subscribe", "/verify-email", "/unsubscribe", "/preferences", "/watch/", "/api/subscribe", "/api/verify-email", "/api/preferences", "/api/watch", "/api/send-preferences-link", "/dev/")
 
@@ -147,6 +163,20 @@ def validate_form_origin():
     if origin and not origin.startswith(EMAIL_BASE_URL) and not origin.startswith(BASE_URL):
         otelLogger.warning(f"Blocked cross-origin form POST from {origin} to {request.path}")
         return Response("Forbidden: cross-origin form submission", status=403)
+
+
+@app.after_request
+def set_security_headers(response):
+    """Apply baseline security headers to every response.
+
+    CSP is deliberately omitted — see issue tracking the in-depth CSP
+    refactor (inline scripts, onclick handlers, and external trackers
+    need to be reworked before a strict policy can be enforced).
+    """
+    response.headers.setdefault('X-Content-Type-Options', 'nosniff')
+    response.headers.setdefault('X-Frame-Options', 'DENY')
+    response.headers.setdefault('Referrer-Policy', 'strict-origin-when-cross-origin')
+    return response
 
 
 @app.after_request
@@ -1037,33 +1067,32 @@ def api_subscribe():
     if cadence not in ('daily', 'weekly'):
         cadence = 'weekly'
     
+    # Generic message used for every non-error outcome to avoid leaking whether
+    # the email is already subscribed, newly created, or pending verification.
+    generic_success_message = (
+        "If this email isn't already subscribed, a verification email is on its way. "
+        "Check your Spam or Junk folder if you don't see it soon."
+    )
+
     try:
         engine = get_engine()
         subscription_id, verification_token = create_email_subscription(engine, email, filters, cadence=cadence)
-        
+
         if not verification_token:
-            return jsonify({"message": "Email is already subscribed and verified"}), 200
-        
-        # Send verification email (async by default)
+            # Already verified — silently accept without re-sending.
+            return jsonify({"message": generic_success_message, "async": False}), 200
+
         email_queued = send_verification_email(email, verification_token, cadence=cadence)
-        if email_queued:
-            if ASYNC_EMAIL_VERIFICATION:
-                return jsonify({
-                    "message": "Subscription created! Verification email is being sent. Make sure to check your Spam or Junk folder if you don't see it soon.",
-                    "async": True
-                }), 201
-            else:
-                return jsonify({
-                    "message": "Subscription created! Verification email sent.",
-                    "async": False
-                }), 201
-        else:
+        if not email_queued:
             otelLogger.warning(f"Subscription created for {email} but verification email failed to initiate")
-            return jsonify({
-                "message": "Subscription created, but the verification email couldn't be sent. Try again later.",
-                "async": ASYNC_EMAIL_VERIFICATION
-            }), 201
-        
+        return jsonify({
+            "message": generic_success_message,
+            "async": ASYNC_EMAIL_VERIFICATION,
+        }), 200
+
+    except EmailRateLimitExceeded:
+        otelLogger.warning(f"Subscribe rate limit hit for {email}")
+        return jsonify({"error": "Too many requests. Please try again later."}), 429
     except Exception as e:
         otelLogger.error(f"Error creating subscription: {e}")
         return jsonify({"error": "Failed to create subscription"}), 500
@@ -1100,6 +1129,7 @@ def api_send_preferences_link():
 
 
 @app.route("/api/verify-email", methods=["GET"])
+@limiter.limit("10 per hour")
 def api_verify_email():
     """Verify email subscription"""
     token = request.args.get('token')
@@ -1380,6 +1410,11 @@ def watch_feature_page(release_item_id):
             return render_template('watch.html', release_item_id=release_item_id,
                                    feature_name=feature_name, product_name=product_name,
                                    success=True)
+        except EmailRateLimitExceeded:
+            otelLogger.warning(f"Watch verification rate limit hit for {email}")
+            return render_template('watch.html', release_item_id=release_item_id,
+                                   feature_name=feature_name, product_name=product_name,
+                                   error="Too many requests. Please try again later."), 429
         except Exception as e:
             otelLogger.error(f"Error creating watch subscription: {e}")
             return render_template('watch.html', release_item_id=release_item_id,


### PR DESCRIPTION
## Summary

Batch of remediations from a full-app security audit. All changes are surgical and backward compatible.

## Changes

### Critical
- **Cryptographically secure tokens** (`db/db_sqlserver.py`): `generate_secure_token()` now uses `secrets.token_urlsafe(48)` instead of `sha256(uuid + time + random.random())`. Output is still exactly 64 chars so it fits the existing `String(64)` token columns, and existing tokens in the DB remain valid (lookups are exact string matches). The non-security `random` import is retained for retry jitter only.

### High
- **HTTPS enforcement for outbound email URLs** (`server.py`): Raises `RuntimeError` at startup if `EMAIL_BASE_URL` doesn't start with `https://` in non-development environments. Tokens embedded in verification/unsubscribe links must not travel over cleartext.
- **`ACS_RESOURCE_ID` required in production** (`server.py`): Raises at startup if unset in non-development. Previously the `if ACS_RESOURCE_ID` check in the email-events webhook was silently skipped when the env var was missing, meaning any caller's events would be processed. Web-mode-only by construction (the refresh job runs pipeline scripts directly and never imports `server.py`).
- **Rate limit on `/api/verify-email`** (`server.py`): Added `@limiter.limit("10 per hour")` to match the existing limit on the HTML `/verify-email` route.

### Medium
- **Per-email verification quota** (`db/db_sqlserver.py` + `server.py`): New `EmailRateLimitExceeded` exception and `_enforce_email_verification_quota()` helper that caps verification emails at 5/hour per address. Called inside both `create_email_subscription` and `create_watch_verification`; endpoints catch and return 429 with a generic message. This complements the existing per-IP rate limits and protects against email-bombing via rotating proxies. Documented as a soft cap (count-then-insert is not atomic, but a few extra emails through is acceptable since the goal is preventing thousands-of-emails abuse).
- **Composite index on `email_verifications(email, created_at)`** (new Alembic migration): Supports the per-email quota query so it uses an index seek instead of a scan as verification history grows. Idempotent up/down using `IF [NOT] EXISTS` to match existing migration style.
- **Security headers** (`server.py`): New `set_security_headers` after_request hook adding `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: strict-origin-when-cross-origin`. CSP is intentionally deferred — see #61 for the follow-up work needed to remove inline scripts/styles before a strict CSP can be enabled.

### Hardening (no security severity, but worth fixing)
- **`/api/subscribe` no longer leaks subscription state** (`server.py`): Previously returned 200 for "already verified" vs 201 for "newly created", which let an attacker enumerate verified emails. Both paths (and the verification-send-failure path) now return a single 200 with a generic "if this email isn't already subscribed, a verification email is on its way" message. Frontend behavior unchanged — the subscribe form only checks `response.ok`.

## Testing

- `python -c "import ast; ast.parse(open(...).read())"` clean for all changed files.
- The migration follows the existing project pattern (`IF NOT EXISTS` SQL Server guards) and chains off the current head `rebuild_email_content_cache`.
- Existing tokens (SHA256-hex format) continue to work after the `generate_secure_token` swap because lookups are exact string matches.

## Follow-ups

- #61 — In-depth CSP refactor (remove inline scripts/styles + handle external trackers).
- Larger separate-PR candidates not included here: `unsubscribe_token` rotation on use, SQL refactor in `get_changelog_with_changes`.
