### PR TITLE
Quality hardening: DB transactions, N+1 fixes, data-driven Last-Modified

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -447,19 +447,27 @@ def deactivate_missing_releases(engine, current_ids: set) -> Dict[str, int]:
 
             now = date.today()
 
-            # Find all currently-active rows whose IDs are not in the fetch
-            active_rows = session.scalars(
-                select(ReleaseItemModel)
+            # Find all currently-active rows whose IDs are not in the fetch.
+            # Server-side filter via NOT IN — only the rows that will actually
+            # change come back, instead of materializing every active row.
+            stale_ids = session.scalars(
+                select(ReleaseItemModel.release_item_id)
                 .where(ReleaseItemModel.active == True)  # noqa: E712
+                .where(ReleaseItemModel.release_item_id.notin_(current_ids) if current_ids else True)
             ).all()
 
-            for row in active_rows:
-                if row.release_item_id not in current_ids:
-                    row.active = False
-                    if not is_first_run:
-                        row.last_modified = now
-                    deactivated += 1
-                    deactivated_ids.append(str(row.release_item_id))
+            deactivated_ids = [str(rid) for rid in stale_ids]
+            deactivated = len(deactivated_ids)
+
+            if deactivated_ids:
+                update_values = {"active": False}
+                if not is_first_run:
+                    update_values["last_modified"] = now
+                session.execute(
+                    update(ReleaseItemModel)
+                    .where(ReleaseItemModel.release_item_id.in_(deactivated_ids))
+                    .values(**update_values)
+                )
 
             # Count rows that were already inactive (informational)
             already_inactive = session.scalar(
@@ -995,57 +1003,57 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
     SessionLocal = sessionmaker(bind=engine, future=True)
     
     with SessionLocal() as session:
-        # Check if subscription already exists
-        existing = session.scalar(
-            select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == email)
-        )
-        
-        if existing and existing.is_verified:
-            # Already subscribed and verified
-            return existing.id, ""
-
-        _enforce_email_verification_quota(session, email)
-
-        verification_token = generate_secure_token()
-        unsubscribe_token = generate_secure_token()
-        
-        if existing:
-            # Update existing unverified subscription
-            existing.verification_token = verification_token
-            existing.unsubscribe_token = unsubscribe_token
-            existing.created_at = datetime.utcnow()
-            existing.is_active = True
-            existing.email_cadence = cadence
-            if filters:
-                existing.product_filter = filters.get('products', '')
-                existing.release_type_filter = filters.get('types', '')
-                existing.release_status_filter = filters.get('statuses', '')
-            subscription_id = existing.id
-        else:
-            # Create new subscription
-            subscription = EmailSubscriptionModel(
-                email=email,
-                verification_token=verification_token,
-                unsubscribe_token=unsubscribe_token,
-                email_cadence=cadence,
-                product_filter=filters.get('products', '') if filters else '',
-                release_type_filter=filters.get('types', '') if filters else '',
-                release_status_filter=filters.get('statuses', '') if filters else ''
+        with session.begin():
+            # Check if subscription already exists
+            existing = session.scalar(
+                select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == email)
             )
-            session.add(subscription)
-            session.flush()
-            subscription_id = subscription.id
-        
-        # Create verification record
-        verification = EmailVerificationModel(
-            email=email,
-            token=verification_token,
-            action_type='subscribe',
-            expires_at=datetime.utcnow() + timedelta(hours=24),
-        )
-        session.add(verification)
-        session.commit()
-        
+
+            if existing and existing.is_verified:
+                # Already subscribed and verified
+                return existing.id, ""
+
+            _enforce_email_verification_quota(session, email)
+
+            verification_token = generate_secure_token()
+            unsubscribe_token = generate_secure_token()
+
+            if existing:
+                # Update existing unverified subscription
+                existing.verification_token = verification_token
+                existing.unsubscribe_token = unsubscribe_token
+                existing.created_at = datetime.utcnow()
+                existing.is_active = True
+                existing.email_cadence = cadence
+                if filters:
+                    existing.product_filter = filters.get('products', '')
+                    existing.release_type_filter = filters.get('types', '')
+                    existing.release_status_filter = filters.get('statuses', '')
+                subscription_id = existing.id
+            else:
+                # Create new subscription
+                subscription = EmailSubscriptionModel(
+                    email=email,
+                    verification_token=verification_token,
+                    unsubscribe_token=unsubscribe_token,
+                    email_cadence=cadence,
+                    product_filter=filters.get('products', '') if filters else '',
+                    release_type_filter=filters.get('types', '') if filters else '',
+                    release_status_filter=filters.get('statuses', '') if filters else ''
+                )
+                session.add(subscription)
+                session.flush()
+                subscription_id = subscription.id
+
+            # Create verification record
+            verification = EmailVerificationModel(
+                email=email,
+                token=verification_token,
+                action_type='subscribe',
+                expires_at=datetime.utcnow() + timedelta(hours=24),
+            )
+            session.add(verification)
+
         return subscription_id, verification_token
 
 
@@ -1065,40 +1073,40 @@ def create_watch_verification(engine, email: str, release_item_id: str) -> Tuple
     SessionLocal = sessionmaker(bind=engine, future=True)
 
     with SessionLocal() as session:
-        _enforce_email_verification_quota(session, email)
+        with session.begin():
+            _enforce_email_verification_quota(session, email)
 
-        existing = session.scalar(
-            select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == email)
-        )
-
-        if existing and existing.is_verified:
-            subscription_id = existing.id
-        elif existing:
-            # Re-use existing unverified subscription
-            existing.created_at = datetime.utcnow()
-            existing.is_active = True
-            subscription_id = existing.id
-        else:
-            # Create a new subscription (will be verified when token is used)
-            sub = EmailSubscriptionModel(
-                email=email,
-                verification_token=generate_secure_token(),
-                unsubscribe_token=generate_secure_token(),
+            existing = session.scalar(
+                select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == email)
             )
-            session.add(sub)
-            session.flush()
-            subscription_id = sub.id
 
-        verification_token = generate_secure_token()
-        verification = EmailVerificationModel(
-            email=email,
-            token=verification_token,
-            action_type='subscribe',
-            expires_at=datetime.utcnow() + timedelta(hours=24),
-            pending_watch_release_id=release_item_id,
-        )
-        session.add(verification)
-        session.commit()
+            if existing and existing.is_verified:
+                subscription_id = existing.id
+            elif existing:
+                # Re-use existing unverified subscription
+                existing.created_at = datetime.utcnow()
+                existing.is_active = True
+                subscription_id = existing.id
+            else:
+                # Create a new subscription (will be verified when token is used)
+                sub = EmailSubscriptionModel(
+                    email=email,
+                    verification_token=generate_secure_token(),
+                    unsubscribe_token=generate_secure_token(),
+                )
+                session.add(sub)
+                session.flush()
+                subscription_id = sub.id
+
+            verification_token = generate_secure_token()
+            verification = EmailVerificationModel(
+                email=email,
+                token=verification_token,
+                action_type='subscribe',
+                expires_at=datetime.utcnow() + timedelta(hours=24),
+                pending_watch_release_id=release_item_id,
+            )
+            session.add(verification)
 
     return subscription_id, verification_token
 
@@ -1112,41 +1120,43 @@ def verify_email_subscription(engine, token: str) -> bool:
     """
     SessionLocal = sessionmaker(bind=engine, future=True)
     
+    pending_release_id = None
+    subscription_id = None
+
     with SessionLocal() as session:
-        # Find verification record
-        verification = session.scalar(
-            select(EmailVerificationModel)
-            .where(EmailVerificationModel.token == token)
-            .where(EmailVerificationModel.action_type == 'subscribe')
-            .where(EmailVerificationModel.is_used == False)
-            .where(EmailVerificationModel.expires_at > datetime.utcnow())
-        )
-        
-        if not verification:
-            return False
-        
-        # Find and update subscription
-        subscription = session.scalar(
-            select(EmailSubscriptionModel)
-            .where(EmailSubscriptionModel.email == verification.email)
-        )
-        
-        if not subscription:
-            return False
-        
-        # Mark as verified
-        subscription.is_verified = True
-        subscription.verified_at = datetime.utcnow()
-        subscription.verification_token = None
-        
-        # Mark verification as used
-        verification.is_used = True
-        verification.used_at = datetime.utcnow()
-        
-        pending_release_id = verification.pending_watch_release_id
-        subscription_id = subscription.id
-        
-        session.commit()
+        with session.begin():
+            # Find verification record
+            verification = session.scalar(
+                select(EmailVerificationModel)
+                .where(EmailVerificationModel.token == token)
+                .where(EmailVerificationModel.action_type == 'subscribe')
+                .where(EmailVerificationModel.is_used == False)
+                .where(EmailVerificationModel.expires_at > datetime.utcnow())
+            )
+
+            if not verification:
+                return False
+
+            # Find and update subscription
+            subscription = session.scalar(
+                select(EmailSubscriptionModel)
+                .where(EmailSubscriptionModel.email == verification.email)
+            )
+
+            if not subscription:
+                return False
+
+            # Mark as verified
+            subscription.is_verified = True
+            subscription.verified_at = datetime.utcnow()
+            subscription.verification_token = None
+
+            # Mark verification as used
+            verification.is_used = True
+            verification.used_at = datetime.utcnow()
+
+            pending_release_id = verification.pending_watch_release_id
+            subscription_id = subscription.id
 
     # Add pending watch outside the verification transaction
     if pending_release_id:
@@ -1166,18 +1176,18 @@ def unsubscribe_email(engine, token: str) -> Optional[str]:
     SessionLocal = sessionmaker(bind=engine, future=True)
 
     with SessionLocal() as session:
-        subscription = session.scalar(_unsubscribe_token_select(token))
+        with session.begin():
+            subscription = session.scalar(_unsubscribe_token_select(token))
 
-        if not subscription:
-            return None
+            if not subscription:
+                return None
 
-        email = subscription.email
-        # Delete by primary key — the input token may be the previous_token,
-        # which would not match a delete keyed on unsubscribe_token.
-        session.execute(
-            delete(EmailSubscriptionModel).where(EmailSubscriptionModel.id == subscription.id)
-        )
-        session.commit()
+            email = subscription.email
+            # Delete by primary key — the input token may be the previous_token,
+            # which would not match a delete keyed on unsubscribe_token.
+            session.execute(
+                delete(EmailSubscriptionModel).where(EmailSubscriptionModel.id == subscription.id)
+            )
         return email
 
 
@@ -1381,10 +1391,12 @@ def update_watch_hashes(engine, hash_updates: List[Tuple[str, str]]):
     SessionLocal = sessionmaker(bind=engine, future=True)
     with SessionLocal() as session:
         with session.begin():
-            for watch_id, new_hash in hash_updates:
-                watch = session.get(FeatureWatchModel, watch_id)
-                if watch:
-                    watch.last_notified_hash = new_hash
+            # Bulk update — single roundtrip instead of one session.get() per id.
+            session.bulk_update_mappings(
+                FeatureWatchModel,
+                [{"id": watch_id, "last_notified_hash": new_hash}
+                 for watch_id, new_hash in hash_updates],
+            )
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)

--- a/server.py
+++ b/server.py
@@ -727,8 +727,18 @@ def build_rss_xml(rows: List[ReleaseItemModel],
     return "\n".join(parts)
 
 
-def _make_cached_response(body: str, mimetype: str = "application/json; charset=utf-8") -> Response:
-    """Build a Response with ETag, Cache-Control, and Last-Modified headers for Front Door caching."""
+def _make_cached_response(
+    body: str,
+    mimetype: str = "application/json; charset=utf-8",
+    last_modified: "datetime | date | None" = None,
+) -> Response:
+    """Build a Response with ETag, Cache-Control, and Last-Modified headers for Front Door caching.
+
+    ``last_modified`` should be the actual most-recent modification time of the
+    underlying data (date or datetime). When omitted, falls back to "now",
+    which prevents `If-Modified-Since` short-circuits — pass a data-derived
+    value whenever available.
+    """
     etag = 'W/"' + hashlib.sha256(body.encode('utf-8')).hexdigest() + '"'
     inm = request.headers.get("If-None-Match")
     if inm and inm == etag:
@@ -736,8 +746,43 @@ def _make_cached_response(body: str, mimetype: str = "application/json; charset=
     resp = Response(body, mimetype=mimetype)
     resp.headers['ETag'] = etag
     resp.headers['Cache-Control'] = f'public, max-age={_FRONT_END_TTL}, stale-while-revalidate={_STALE_TTL}, must-revalidate'
-    resp.headers['Last-Modified'] = format_datetime(datetime.now(timezone.utc))
+
+    lm_dt: datetime
+    if isinstance(last_modified, datetime):
+        lm_dt = last_modified if last_modified.tzinfo else last_modified.replace(tzinfo=timezone.utc)
+    elif isinstance(last_modified, date):
+        lm_dt = datetime.combine(last_modified, time.min, tzinfo=timezone.utc)
+    else:
+        lm_dt = datetime.now(timezone.utc)
+    resp.headers['Last-Modified'] = format_datetime(lm_dt)
     return resp
+
+
+def _max_last_modified(items, attr: str = "last_modified"):
+    """Pick the maximum non-null last_modified value from a list of dicts or ORM rows.
+
+    Accepts ISO strings, date, or datetime values. Returns the most recent as a
+    UTC datetime, or None when nothing is set.
+    """
+    best: "datetime | None" = None
+    for it in items or ():
+        val = it.get(attr) if isinstance(it, dict) else getattr(it, attr, None)
+        if val is None:
+            continue
+        if isinstance(val, str):
+            try:
+                val = datetime.fromisoformat(val)
+            except ValueError:
+                continue
+        if isinstance(val, datetime):
+            dt_val = val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+        elif isinstance(val, date):
+            dt_val = datetime.combine(val, time.min, tzinfo=timezone.utc)
+        else:
+            continue
+        if best is None or dt_val > best:
+            best = dt_val
+    return best
 
 
 @app.get("/rss")
@@ -760,7 +805,11 @@ def rss_feed():
         release_status=release_status,
     )
     xml = build_rss_xml(rows, link=EMAIL_BASE_URL, description=f"Up to {limit} most recently modified releases")
-    return _make_cached_response(xml, mimetype="application/rss+xml; charset=utf-8")
+    return _make_cached_response(
+        xml,
+        mimetype="application/rss+xml; charset=utf-8",
+        last_modified=_max_last_modified(rows),
+    )
 
 
 @app.get("/")
@@ -924,7 +973,7 @@ def api_releases():
                 return jsonify({"error": "release_item_id not found"}), 404
             data = _row_to_dict(row)
             json_item = json.dumps(data, sort_keys=True, separators=(",", ":"))
-            return _make_cached_response(json_item)
+            return _make_cached_response(json_item, last_modified=row.last_modified)
 
     # Generate embedding for vector search when q is provided
     query_embedding = None
@@ -1001,7 +1050,7 @@ def api_releases():
         "links": links,
     }
     json_str = json.dumps(envelope, sort_keys=True, separators=(",", ":"))
-    resp = _make_cached_response(json_str)
+    resp = _make_cached_response(json_str, last_modified=_max_last_modified(data_rows))
     if links.get("next") or links.get("prev"):
         link_header_parts = []
         if links.get("next"): link_header_parts.append(f"<{links['next']}>; rel=\"next\"")
@@ -1398,7 +1447,7 @@ def api_release_history(release_item_id: str):
     """
     rows = fetch_history_rows(get_engine(), release_item_id)
     json_str = json.dumps(rows, sort_keys=True, separators=(",", ":"))
-    return _make_cached_response(json_str)
+    return _make_cached_response(json_str, last_modified=_max_last_modified(rows))
 
 
 @app.get("/about")
@@ -1507,7 +1556,7 @@ def api_changelog():
 
     body = json.dumps({"days": days_list, "total_items": len(items)},
                        separators=(",", ":"), sort_keys=True)
-    return _make_cached_response(body)
+    return _make_cached_response(body, last_modified=_max_last_modified(items))
 
 
 @app.post("/webhooks/email-events")


### PR DESCRIPTION
# Quality hardening: DB transactions, N+1 fixes, data-driven `Last-Modified`

Addresses the four HIGH-severity findings from the recent code-quality review (full report in session workspace). Single coherent PR because all four touch `db/db_sqlserver.py` or the cached-response plumbing in `server.py`.

## H1 — Wrap bare `session.commit()` in `with session.begin():`

`db/db_sqlserver.py` had four writers using a bare `session.commit()` without a context manager:

- `create_email_subscription`
- `create_watch_verification`
- `verify_email_subscription`
- `unsubscribe_email`

The other eight writers in the module already use `with session.begin():`, which auto-rolls-back on exception. These four didn't — meaning a failure between begin and commit would leave the session dirty before being returned to the pool. Wrapped each in `with session.begin():` and removed the explicit commit. Local variables that need to outlive the transaction (e.g. `subscription_id`, `pending_release_id` in `verify_email_subscription`) are captured before the block exits.

## H2 — Plumb data-driven `Last-Modified` headers

`_make_cached_response` was setting `Last-Modified: <now>` on every cached response. That defeats `If-Modified-Since` short-circuits at both the browser and Azure Front Door — clients always have to download the body to validate the ETag.

Changes:

- `_make_cached_response` now accepts an optional `last_modified: datetime | date | None`. When omitted, it still falls back to `now()` (preserves prior behavior for static-ish endpoints).
- New `_max_last_modified(items, attr="last_modified")` helper picks the most-recent value from a list of dicts or ORM rows. Accepts ISO strings, `date`, or `datetime` and normalizes to UTC `datetime`.
- Wired data-derived timestamps through 5 callers:
  - `/rss`, `/rss.xml` → max of returned rows
  - `/api/releases` (single item) → `row.last_modified`
  - `/api/releases` (list) → max of envelope's `data` rows
  - `/api/releases/history/<id>` → max of history rows
  - `/api/changelog` → max of returned items
- `/api/filter-options` and `/endpoints` have no natural data timestamp and keep the `now()` fallback.

## H3 — Bulk update in `update_watch_hashes`

Was: one `session.get(FeatureWatchModel, watch_id)` per item, then per-row attribute assignment. After a roadmap refresh that touches N watches, that's N + 1 round-trips to Azure SQL inside `weekly_email_job`.

Now: single `bulk_update_mappings` call. Same silently-skips-missing-id semantics as before; one round-trip total.

## H4 — Single-query `deactivate_missing_releases`

Was: `SELECT * FROM release_items WHERE active=1`, materialize every row in Python, iterate and Python-side-filter against `current_ids`, then ORM-flush each change.

Now: one `SELECT release_item_id WHERE active=1 AND id NOT IN :current_ids` to identify stale rows + one bulk `UPDATE` to flip them. Empty-set guard prevents an `IN ()` syntax error when nothing is stale. First-run semantics preserved (no `last_modified` bump on initial backfill).

## Validation

- `python -c "import ast; ast.parse(...)"` clean on both modified files.
- LSP diagnostics on `db/db_sqlserver.py`: no warnings/errors (clean baseline).
- LSP diagnostics on `server.py`: only pre-existing pylint info-level findings, none in the changed regions.
- `code-review` sub-agent reviewed the full diff and reported no significant issues; specifically verified:
  - All four `session.begin():` wrappers are correct (early returns commit empty tx — harmless).
  - `bulk_update_mappings` matches original silent-skip-missing-id behavior.
  - `_max_last_modified` correctly handles both date-only and datetime ISO strings via `fromisoformat`.
  - The `if deactivated_ids:` guard is necessary to avoid an empty-IN SQL error.

## Out of scope (filed as follow-ups)

- **H5** — pipeline-script retry decorator + per-item progress markers. Bigger refactor; will be its own PR after this one merges.
- **H6** — pytest scaffold + coverage on `weekly_email_job._get_subscriber_content` daily-cadence path.
- All MEDIUM/LOW findings from the review.
