### PR TITLE
H5: Apply Azure SQL transient retry to pipeline scripts; per-article RSS commits

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -6,8 +6,6 @@ from collections import defaultdict
 from datetime import datetime, date, timedelta
 from typing import Iterable, Any, Tuple, Dict
 import urllib.parse
-import time
-import random
 import secrets
 import logging
 
@@ -18,8 +16,12 @@ from sqlalchemy import (
 from typing import Iterable, Any, Tuple, Dict, Optional, List
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-# SQLAlchemy-specific exceptions we may inspect
-from sqlalchemy.exc import DBAPIError
+# Retry decorator lives in lib/db_retry.py so raw-pyodbc pipeline scripts
+# can share the same Azure-SQL transient-error detection.
+from lib.db_retry import (
+    retry_on_transient_errors,
+    is_transient_sql_azure_error as _retry_is_transient,
+)
 
 naming_convention = {
     "ix": "ix_%(column_0_label)s",
@@ -143,100 +145,14 @@ class EmailContentCacheModel(Base):
 
 
 def _is_transient_sql_azure_error(exc: Exception) -> bool:
-    """
-    Try to detect common transient SQL Azure / network errors.
-    Inspect message text and DBAPI/SQL error codes found in the exception.
-    """
-    if exc is None:
-        return False
-
-    # Known SQL/Azure transient error codes & phrases (string search)
-    transient_codes = {
-        "40197", "40501", "40613", "10928", "10929", "49918", "49919", "49920", "4060",
-        "10053", "10054", "10060", "1205",  # 1205 = deadlock; sometimes transient as well
-    }
-    msg = str(exc).lower()
-
-    # check presence of numeric codes
-    for code in transient_codes:
-        if code in msg:
-            return True
-
-    # common transient / network phrases
-    transient_phrases = (
-        "transport-level error",
-        "a transport-level error has occurred",
-        "the connection is broken",
-        "connection reset by peer",
-        "connection was closed by the server",
-        "the server was not found or was not accessible",
-        "cannot open database requested by the login",
-        "login failed",
-        "connection timeout",
-        "timed out",
-        "timeout expired",
-        "operation timed out",
-        "could not open connection",
-        "server is busy",
-        "service is currently paused",
-        "service is busy",
-        "deadlocked",  # fallback
-    )
-    for ph in transient_phrases:
-        if ph in msg:
-            return True
-
-    # inspect SQLAlchemy DBAPIError .orig (if present) for underlying DBAPI messages
-    try:
-        if isinstance(exc, DBAPIError):
-            orig = getattr(exc, "orig", None)
-            if orig is not None and any(code in str(orig) for code in transient_codes):
-                return True
-            # connection_invalidated is often True when SQLAlchemy detects a disconnect
-            if getattr(exc, "connection_invalidated", False):
-                return True
-    except Exception:
-        pass
-
-    return False
+    """Backwards-compatible alias — see :func:`lib.db_retry.is_transient_sql_azure_error`."""
+    return _retry_is_transient(exc)
 
 
-def retry_on_transient_errors(max_attempts: int = 5, initial_delay: float = 1.0, backoff: float = 2.0, max_delay: float = 30.0):
-    """
-    Decorator to retry a DB operation on transient SQL Azure / network errors.
-
-    Usage:
-      @retry_on_transient_errors()
-      def init_db(...):
-          ...
-    """
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            attempt = 1
-            delay = float(initial_delay)
-            while True:
-                try:
-                    return func(*args, **kwargs)
-                except Exception as exc:
-                    if not _is_transient_sql_azure_error(exc):
-                        logger.exception("Non-transient DB error encountered, not retrying.")
-                        raise
-                    if attempt >= max_attempts:
-                        logger.exception("Transient DB error and max attempts reached (%d).", max_attempts)
-                        raise
-                    # transient and we will retry
-                    logger.warning("Transient DB error detected; attempt %d/%d will retry after %.2fs: %s",
-                                   attempt, max_attempts, delay, exc)
-                    # jitter
-                    sleep_time = delay + (random.random() * 0.5)
-                    time.sleep(sleep_time)
-                    delay = min(delay * backoff, max_delay)
-                    attempt += 1
-        # copy some identity
-        wrapper.__name__ = getattr(func, "__name__", "wrapped")
-        wrapper.__doc__ = getattr(func, "__doc__", "")
-        return wrapper
-    return decorator
+# retry_on_transient_errors is re-exported from lib.db_retry (extracted so
+# raw-pyodbc pipeline scripts can use the same decorator without depending
+# on the SQLAlchemy module). The aliasing preserves the public API for
+# callers that still import these symbols from db.db_sqlserver.
 
 
 def make_engine(conn_str: str | None = None):

--- a/lib/db_retry.py
+++ b/lib/db_retry.py
@@ -1,0 +1,148 @@
+"""Retry helpers for transient Azure SQL / network errors.
+
+Both the SQLAlchemy paths in ``db.db_sqlserver`` and the raw-pyodbc pipeline
+scripts (vectorize, match, scrape) need the same backoff behavior when Azure
+SQL throttles, fails over, or drops a connection. This module centralizes that
+logic so a single tweak in detection/timing applies everywhere.
+
+Usage::
+
+    from lib.db_retry import retry_on_transient_errors
+
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5)
+    def update_blog_vector(post_id, embedding):
+        ...
+"""
+
+import logging
+import random
+import time
+
+# SQLAlchemy is optional for this module — pipeline scripts that use only
+# raw pyodbc don't need it. Guard the import so importing ``lib.db_retry``
+# in a SQLAlchemy-less context doesn't fail.
+try:
+    from sqlalchemy.exc import DBAPIError as _DBAPIError
+except Exception:  # pragma: no cover — sqlalchemy missing
+    _DBAPIError = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+
+# Known SQL Azure transient error codes & phrases. Conservative on purpose —
+# anything in this set will trigger a retry, so non-transient phrases must
+# stay out (e.g. plain "syntax error", "permission denied", etc.).
+_TRANSIENT_CODES = frozenset({
+    "40197", "40501", "40613", "10928", "10929", "49918", "49919", "49920", "4060",
+    "10053", "10054", "10060",
+    "1205",  # deadlock — frequently transient
+})
+
+_TRANSIENT_PHRASES = (
+    "transport-level error",
+    "a transport-level error has occurred",
+    "the connection is broken",
+    "connection reset by peer",
+    "connection was closed by the server",
+    "the server was not found or was not accessible",
+    "cannot open database requested by the login",
+    "login failed",
+    "connection timeout",
+    "timed out",
+    "timeout expired",
+    "operation timed out",
+    "could not open connection",
+    "server is busy",
+    "service is currently paused",
+    "service is busy",
+    "deadlocked",
+)
+
+
+def is_transient_sql_azure_error(exc: Exception) -> bool:
+    """Best-effort detection of common transient Azure SQL / network errors.
+
+    Inspects the exception message and any DBAPI ``orig`` attribute for known
+    transient SQL codes and phrases. Conservative — when in doubt, returns
+    False so non-transient bugs aren't silently retried.
+    """
+    if exc is None:
+        return False
+
+    msg = str(exc).lower()
+
+    for code in _TRANSIENT_CODES:
+        if code in msg:
+            return True
+
+    for phrase in _TRANSIENT_PHRASES:
+        if phrase in msg:
+            return True
+
+    # If SQLAlchemy is available, peek at DBAPIError.orig for the underlying
+    # pyodbc / pymssql exception text, and honor connection_invalidated.
+    if _DBAPIError is not None:
+        try:
+            if isinstance(exc, _DBAPIError):
+                orig = getattr(exc, "orig", None)
+                if orig is not None and any(code in str(orig) for code in _TRANSIENT_CODES):
+                    return True
+                if getattr(exc, "connection_invalidated", False):
+                    return True
+        except Exception:  # noqa: BLE001 — best-effort detection
+            pass
+
+    return False
+
+
+# Backwards-compatible alias used by db.db_sqlserver before the extraction.
+_is_transient_sql_azure_error = is_transient_sql_azure_error
+
+
+def retry_on_transient_errors(
+    max_attempts: int = 5,
+    initial_delay: float = 1.0,
+    backoff: float = 2.0,
+    max_delay: float = 30.0,
+):
+    """Decorator that retries a callable on transient Azure SQL errors.
+
+    Uses exponential backoff with up-to-0.5s jitter. Non-transient exceptions
+    re-raise immediately (no silent swallowing).
+
+    Args:
+        max_attempts: Total attempts including the first call.
+        initial_delay: Seconds to wait before the second attempt.
+        backoff: Multiplier applied to the delay after each retry.
+        max_delay: Upper bound on the per-retry delay.
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            attempt = 1
+            delay = float(initial_delay)
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:  # noqa: BLE001 — classification handled below
+                    if not is_transient_sql_azure_error(exc):
+                        logger.exception("Non-transient DB error encountered, not retrying.")
+                        raise
+                    if attempt >= max_attempts:
+                        logger.exception("Transient DB error and max attempts reached (%d).", max_attempts)
+                        raise
+                    logger.warning(
+                        "Transient DB error detected; attempt %d/%d will retry after %.2fs: %s",
+                        attempt, max_attempts, delay, exc,
+                    )
+                    sleep_time = delay + (random.random() * 0.5)
+                    time.sleep(sleep_time)
+                    delay = min(delay * backoff, max_delay)
+                    attempt += 1
+
+        wrapper.__name__ = getattr(func, "__name__", "wrapped")
+        wrapper.__doc__ = getattr(func, "__doc__", "")
+        wrapper.__wrapped__ = func  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/match_releases_to_blogs.py
+++ b/match_releases_to_blogs.py
@@ -12,6 +12,8 @@ import pyodbc
 from openai import AzureOpenAI
 import json
 
+from lib.db_retry import retry_on_transient_errors, is_transient_sql_azure_error
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -60,6 +62,38 @@ class ReleaseBlogMatcher:
             self.conn = pyodbc.connect(self.connection_string)
             self.cursor = self.conn.cursor()
             logger.info("Database connection established")
+
+    def _ensure_connection(self):
+        """Reconnect if the connection has been dropped (used by retry path)."""
+        if self.conn is None or self.cursor is None:
+            self.connect()
+
+    def _drop_connection_silently(self):
+        """Close and clear the current connection so the next attempt reconnects."""
+        try:
+            if self.cursor is not None:
+                self.cursor.close()
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+        try:
+            if self.conn is not None:
+                self.conn.close()
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+        self.cursor = None
+        self.conn = None
+
+    def _run_with_reconnect(self, body):
+        """Run *body* (a no-arg callable) under reconnect-on-transient-error semantics."""
+        try:
+            self._ensure_connection()
+            return body()
+        except Exception as exc:
+            if is_transient_sql_azure_error(exc):
+                # Drop the (likely broken) connection so the retry decorator's
+                # next attempt establishes a fresh one before re-running body.
+                self._drop_connection_silently()
+            raise
     
     def close(self):
         """Close database connection"""
@@ -76,24 +110,25 @@ class ReleaseBlogMatcher:
         if self.conn:
             self.conn.commit()
     
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def get_releases_without_articles(self) -> List[Dict]:
         """
         Fetch releases that have null blog_url
-        
+
         Returns:
             List of dictionaries containing release data
         """
-        try:
+        def body():
             query = """
             SELECT release_item_id, feature_name, product_name, feature_description, release_vector
             FROM release_items
             WHERE blog_url IS NULL
             ORDER BY last_modified DESC
             """
-            
+
             self.cursor.execute(query)
             rows = self.cursor.fetchall()
-            
+
             releases = []
             for row in rows:
                 releases.append({
@@ -103,13 +138,11 @@ class ReleaseBlogMatcher:
                     'feature_description': row[3] or '',
                     'release_vector': row[4] or ''
                 })
-            
+
             logger.info(f"Found {len(releases)} releases without blogs")
             return releases
-        
-        except Exception as e:
-            logger.error(f"Error fetching releases without blogs: {e}")
-            raise
+
+        return self._run_with_reconnect(body)
     
     def create_text_for_embedding(self, release: Dict) -> str:
         """
@@ -165,46 +198,47 @@ class ReleaseBlogMatcher:
             logger.error(f"Error generating embedding: {e}")
             return None
     
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def update_release_vector(self, release_item_id: str, embedding) -> bool:
         """
         Update the release_vector column for a specific release
-        
+
         Args:
             release_item_id: Database ID of the release
             embedding: OpenAI embedding response object
-            
+
         Returns:
-            True if successful, False otherwise
+            True if successful. Raises after retry exhaustion; the caller's
+            per-item try/except is expected to catch and count as a failure.
         """
-        try:
+        def body():
             update_sql = """
             UPDATE release_items
             SET release_vector = JSON_QUERY(CAST(? AS NVARCHAR(MAX)), '$.data[0].embedding')
             WHERE release_item_id = ?
             """
-            
+
             self.cursor.execute(update_sql, (embedding.model_dump_json(), release_item_id))
             self.commit()
-            
             return True
-        
-        except Exception as e:
-            logger.error(f"Error updating vector for release {release_item_id}: {e}")
-            return False
-    
+
+        return self._run_with_reconnect(body)
+
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def find_most_related_blog(self, release_item_id) -> Optional[Tuple[str, str, float]]:
         """
         Find the most related blog article using vector similarity
-        
+
         Args:
             release_item_id: ID of release_item to find blog
-            
+
         Returns:
-            Tuple of (blog_title, blog_url, distance) or None if no match found
+            Tuple of (blog_title, blog_url, distance) or None if no match found.
+            Raises after retry exhaustion; the caller is expected to catch.
         """
-        try:
+        def body():
             query = """
-            SELECT TOP 1 title, url, 
+            SELECT TOP 1 title, url,
                    VECTOR_DISTANCE('cosine', (SELECT release_vector FROM release_items WHERE release_item_id = ?), blog_vector) as distance
             FROM fabric_blog_posts
             WHERE blog_vector IS NOT NULL
@@ -213,29 +247,29 @@ class ReleaseBlogMatcher:
 
             self.cursor.execute(query, (release_item_id,))
             row = self.cursor.fetchone()
-            
+
             if row:
                 return (row[0], row[1], row[2])
-            
+
             return None
-        
-        except Exception as e:
-            logger.error(f"Error finding related blog: {e}")
-            return None
+
+        return self._run_with_reconnect(body)
     
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def update_release_blog_info(self, release_item_id: str, blog_title: str, blog_url: str, distance) -> bool:
         """
         Update the blog_title and blog_url columns for a specific release
-        
+
         Args:
             release_item_id: Database ID of the release
             blog_title: Title of the related blog article
             blog_url: URL of the related blog article
-            
+
         Returns:
-            True if successful, False otherwise
+            True if successful. Raises after retry exhaustion; the caller is
+            expected to catch and count as a failure.
         """
-        try:
+        def body():
             update_sql = """
             UPDATE release_items
             SET blog_title = ?,
@@ -243,15 +277,12 @@ class ReleaseBlogMatcher:
                 vector_distance = ?
             WHERE release_item_id = ?
             """
-            
+
             self.cursor.execute(update_sql, (blog_title, blog_url, distance, release_item_id))
             self.commit()
-            
             return True
-        
-        except Exception as e:
-            logger.error(f"Error updating blog info for release {release_item_id}: {e}")
-            return False
+
+        return self._run_with_reconnect(body)
     
     def vectorize_and_match_all_releases(self):
         """
@@ -339,9 +370,10 @@ class ReleaseBlogMatcher:
             raise
 
 
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def get_all_matched_releases(self) -> List[Dict]:
         """Fetch all releases that already have a blog match and a vector."""
-        try:
+        def body():
             query = """
             SELECT release_item_id, feature_name, product_name,
                    blog_title, blog_url, vector_distance
@@ -363,9 +395,8 @@ class ReleaseBlogMatcher:
                 }
                 for row in rows
             ]
-        except Exception as e:
-            logger.error(f"Error fetching matched releases: {e}")
-            raise
+
+        return self._run_with_reconnect(body)
 
     def rerank_all_matches(self):
         """Re-check all matched releases for a better blog article.

--- a/scrape_fabric_blog.py
+++ b/scrape_fabric_blog.py
@@ -21,6 +21,8 @@ from urllib.parse import urljoin
 import xml.etree.ElementTree as ET
 import html
 
+from lib.db_retry import retry_on_transient_errors
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -197,7 +199,7 @@ class FabricBlogScraper:
     def insert_or_update_article(self, cursor, article: Dict):
         """
         Insert article into database or update if URL already exists
-        
+
         Args:
             cursor: Database cursor
             article: Dictionary containing article data
@@ -237,61 +239,104 @@ class FabricBlogScraper:
             article['views'],
             article['summary']
         ))
+
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+    def upsert_article_with_retry(self, article: Dict):
+        """Open a fresh connection, upsert the article, commit, and close.
+
+        Per-article connection management is heavier than batching, but the
+        MERGE upsert is idempotent on URL so retries after a transient failure
+        are safe, and per-call commit means a mid-loop crash never loses a
+        previously-processed article.
+        """
+        conn = None
+        cursor = None
+        try:
+            conn = pyodbc.connect(self.connection_string)
+            cursor = conn.cursor()
+            self.insert_or_update_article(cursor, article)
+            conn.commit()
+        finally:
+            if cursor is not None:
+                try:
+                    cursor.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
+
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+    def article_exists(self, url: str) -> bool:
+        """Check whether an article with this URL is already in the database."""
+        conn = None
+        cursor = None
+        try:
+            conn = pyodbc.connect(self.connection_string)
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COUNT(*) FROM fabric_blog_posts WHERE url = ?",
+                (url,),
+            )
+            return cursor.fetchone()[0] > 0
+        finally:
+            if cursor is not None:
+                try:
+                    cursor.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
     
     def scrape_all_pages(self, start_page: int = 1, end_page: int = 169):
         """
         Scrape all blog pages and store in database
-        
+
         Args:
             start_page: First page to scrape (default: 1)
             end_page: Last page to scrape (default: 169)
         """
         try:
-            conn = pyodbc.connect(self.connection_string)
-            cursor = conn.cursor()
-            
-            # Ensure table exists
-            #self.create_table_if_not_exists(cursor)
-            #conn.commit()
-            
             total_articles = 0
             failed_pages = []
-            
+
             for page_num in range(start_page, end_page + 1):
                 logger.info(f"Processing page {page_num}/{end_page}")
-                
+
                 soup = self.fetch_page(page_num)
                 if not soup:
                     failed_pages.append(page_num)
                     continue
-                
+
                 articles = self.extract_articles(soup)
                 logger.info(f"Found {len(articles)} articles on page {page_num}")
-                
-                # Insert articles into database
+
+                # Insert articles into database (per-article connection + retry).
+                page_success = 0
                 for article in articles:
                     try:
-                        self.insert_or_update_article(cursor, article)
+                        self.upsert_article_with_retry(article)
                         total_articles += 1
+                        page_success += 1
                     except Exception as e:
                         logger.error(f"Failed to insert article '{article.get('title')}': {e}")
-                
-                # Commit after each page
-                conn.commit()
-                logger.info(f"Committed {len(articles)} articles from page {page_num}")
-            
+
+                logger.info(f"Committed {page_success}/{len(articles)} articles from page {page_num}")
+
             # Final summary
             logger.info("=" * 60)
             logger.info(f"Scraping complete!")
             logger.info(f"Total articles processed: {total_articles}")
             logger.info(f"Pages scraped: {end_page - start_page + 1 - len(failed_pages)}/{end_page - start_page + 1}")
-            
+
             if failed_pages:
                 logger.warning(f"Failed pages: {failed_pages}")
-            
-            cursor.close()
-            conn.close()
-            
+
         except Exception as e:
             logger.error(f"Fatal error during scraping: {e}")
             raise
@@ -461,72 +506,56 @@ class FabricBlogScraper:
         Scrape articles from RSS feed and store in database (delta load)
         """
         try:
-            conn = pyodbc.connect(self.connection_string)
-            cursor = conn.cursor()
-            
-            # Ensure table exists
-            # self.create_table_if_not_exists(cursor)
-            # conn.commit()
-            
             # Fetch RSS feed
             root = self.fetch_rss_feed()
             if not root:
                 logger.error("Failed to fetch RSS feed")
                 return
-            
+
             # Extract articles from RSS
             articles = self.extract_articles_from_rss(root)
             logger.info(f"Extracted {len(articles)} articles from RSS feed")
-            
+
             new_count = 0
             updated_count = 0
-            
-            # Insert articles into database
+
+            # Insert articles into database. Each article gets its own
+            # connection + commit + retry, so a transient SQL error or a
+            # mid-loop crash never loses already-processed articles.
             for article in articles:
                 try:
                     trimmed_url = article['url'].rstrip('/')
-                    # Check if article already exists
-                    cursor.execute(
-                        "SELECT COUNT(*) FROM fabric_blog_posts WHERE url = ?",
-                        (trimmed_url,)
-                    )
-                    exists = cursor.fetchone()[0] > 0
-                    
+                    exists = self.article_exists(trimmed_url)
+
                     # For new articles, fetch additional details from the article page
                     if not exists:
                         logger.info(f"New article found: {article['title']}")
                         article_details = self.fetch_article_details(article['url'])
-                        
+
                         if article_details:
                             # Update article with fetched details if not already present in RSS
                             if not article.get('categories') and article_details.get('categories'):
                                 article['categories'] = article_details['categories']
                             if not article.get('author') and article_details.get('author'):
                                 article['author'] = article_details['author']
-                    
-                    self.insert_or_update_article(cursor, article)
-                    
+
+                    self.upsert_article_with_retry(article)
+
                     if exists:
                         updated_count += 1
                     else:
                         new_count += 1
-                    
+
                 except Exception as e:
                     logger.error(f"Failed to insert article '{article.get('title')}': {e}")
-            
-            # Commit all changes
-            conn.commit()
-            
+
             # Final summary
             logger.info("=" * 60)
             logger.info(f"RSS feed scraping complete!")
             logger.info(f"New articles: {new_count}")
             logger.info(f"Updated articles: {updated_count}")
             logger.info(f"Total processed: {len(articles)}")
-            
-            cursor.close()
-            conn.close()
-            
+
         except Exception as e:
             logger.error(f"Fatal error during RSS scraping: {e}")
             raise

--- a/vectorize_blog_posts.py
+++ b/vectorize_blog_posts.py
@@ -12,6 +12,8 @@ from typing import List, Dict, Optional
 import pyodbc
 from openai import AzureOpenAI
 
+from lib.db_retry import retry_on_transient_errors
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -48,27 +50,30 @@ class BlogVectorizer:
         
         logger.info("BlogVectorizer initialized successfully")
     
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def get_posts_without_vectors(self) -> List[Dict]:
         """
         Fetch blog posts that have null blog_vector
-        
+
         Returns:
             List of dictionaries containing post data
         """
+        conn = None
+        cursor = None
         try:
             conn = pyodbc.connect(self.connection_string)
             cursor = conn.cursor()
-            
+
             query = """
             SELECT id, title, categories, summary, url
             FROM fabric_blog_posts
             WHERE blog_vector IS NULL
             ORDER BY post_date DESC
             """
-            
+
             cursor.execute(query)
             rows = cursor.fetchall()
-            
+
             posts = []
             for row in rows:
                 posts.append({
@@ -78,16 +83,20 @@ class BlogVectorizer:
                     'summary': row[3] or '',
                     'url': row[4] or ''
                 })
-            
-            cursor.close()
-            conn.close()
-            
+
             logger.info(f"Found {len(posts)} posts without vectors")
             return posts
-        
-        except Exception as e:
-            logger.error(f"Error fetching posts without vectors: {e}")
-            raise
+        finally:
+            if cursor is not None:
+                try:
+                    cursor.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
     
     def create_text_for_embedding(self, post: Dict) -> str:
         """
@@ -145,38 +154,43 @@ class BlogVectorizer:
             logger.error(f"Error generating embedding: {e}")
             return None
     
+    @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def update_post_vector(self, post_id: int, embedding) -> bool:
         """
         Update the blog_vector column for a specific post
-        
+
         Args:
             post_id: Database ID of the post
             vector: Embedding vector to store
-            
+
         Returns:
-            True if successful, False otherwise
+            True if successful. Raises on database error after retry exhaustion;
+            the caller is expected to catch and count as a failure.
         """
+        conn = None
+        cursor = None
         try:
             conn = pyodbc.connect(self.connection_string)
             cursor = conn.cursor()
-            
-            # Convert vector to JSON string format for SQL Server vector type
-            
+
             update_sql = """
             UPDATE fabric_blog_posts SET blog_vector = JSON_QUERY(CAST(? AS NVARCHAR(MAX)), '$.data[0].embedding') WHERE id = ?
             """
-            
+
             cursor.execute(update_sql, (embedding.model_dump_json(), post_id))
             conn.commit()
-            
-            cursor.close()
-            conn.close()
-            
             return True
-        
-        except Exception as e:
-            logger.error(f"Error updating vector for post ID {post_id}: {e}")
-            return False
+        finally:
+            if cursor is not None:
+                try:
+                    cursor.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
     
     def vectorize_all_posts(self, batch_size: int = 10):
         """


### PR DESCRIPTION
# H5: Apply Azure SQL transient retry to pipeline scripts; per-article commits in RSS scraper

Second of the high-priority fixes from the code-quality review. Brings the raw-pyodbc pipeline scripts up to the same Azure SQL resilience level as the SQLAlchemy-based code in `db/db_sqlserver.py`.

## What changed

### `lib/db_retry.py` (new)
Extracted the `retry_on_transient_errors` decorator and `is_transient_sql_azure_error` helper out of `db/db_sqlserver.py` into a shared module. The SQLAlchemy `DBAPIError` import is guarded with `try/except` so the raw-pyodbc pipeline scripts can import the module without pulling in SQLAlchemy.

### `db/db_sqlserver.py`
Now imports retry helpers from `lib.db_retry`. `_is_transient_sql_azure_error` is kept as a backward-compat alias. Removed the now-unused `time`, `random`, and `DBAPIError` imports.

### `vectorize_blog_posts.py`
Decorated `get_posts_without_vectors` and `update_post_vector` with `@retry_on_transient_errors`. Refactored the bodies to use `try/finally` for cleanup and removed the inner `except: return False` patterns so the decorator can actually see transient exceptions and retry. The caller's per-item `try/except` loop still catches and counts post-retry failures.

### `match_releases_to_blogs.py`
Class-based with shared `self.conn`/`self.cursor`. Added three small helpers:
- `_ensure_connection()` — establish conn lazily if missing
- `_drop_connection_silently()` — close + null out conn/cursor on transient failure
- `_run_with_reconnect(body)` — runs `body()`, drops conn on transient so the next retry attempt reconnects

All five DB methods (`get_releases_without_articles`, `update_release_vector`, `find_most_related_blog`, `update_release_blog_info`, `get_all_matched_releases`) are now decorated with retry and use the reconnect helper.

### `scrape_fabric_blog.py`
Refactored from per-page connection sharing to per-article connection management. Added two new methods:
- `upsert_article_with_retry(article)` — opens its own conn, calls the existing `insert_or_update_article(cursor, ...)`, commits, closes; decorated with retry
- `article_exists(url)` — same connection lifecycle for the RSS dedup check

`scrape_all_pages` and `scrape_from_rss` now call these instead of managing a long-lived shared connection. The MERGE upsert is idempotent on URL so retries are safe.

**Bonus fix:** `scrape_from_rss` previously committed once at the end of the loop. A transient SQL error or any mid-loop crash would lose every article processed so far. With the new per-article commits, a crash mid-loop only loses the in-flight article.

## Why no per-item progress markers (the "(b)" subtask)
The original H5 finding mentioned adding "last-processed-id markers" so a crashed run could resume. Looking at the code, the `WHERE blog_vector IS NULL` and `WHERE blog_url IS NULL` filters in `vectorize_blog_posts.py` and `match_releases_to_blogs.py` already serve as free progress markers — each item is committed independently and the next run only picks up unprocessed items. No additional bookkeeping needed.

## Retry parameters
All pipeline decorations use `max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0`, matching the user-facing/pipeline ops in `db_sqlserver.py`. The slower `5/60s` settings remain reserved for the email/subscription functions where a longer backoff is acceptable.

## Verified
- All five modified files parse cleanly (`ast.parse`).
- VS Code diagnostics show no new errors in the modified files.
- `code-review` agent run on the staged diff surfaced no blocking issues.

## Out of scope
- H6 (test scaffold) — tracked in a separate GitHub issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
