### PR TITLE
H6 + test scaffold: pytest, _filter_by_cadence helper, 79 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install ODBC system deps
+        # pyodbc is in requirements.txt and links against unixodbc at install
+        # time. We don't run any tests that hit SQL Server, but the wheel
+        # still needs the headers to import cleanly.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends unixodbc unixodbc-dev
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Small Flask server that exposes an RSS 2.0 feed and basic REST API for the Fabric Roadmap
 
+## Tests
+
+Unit tests live in `tests/` and are run with pytest. They cover pure-Python helpers (no live SQL Server or network needed) — currently the Azure SQL retry decorator, the daily/weekly email-cadence filter, and the `ReleaseItem` parsing helpers.
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
 ## Email Subscriptions
 
 Subscribers can receive digest emails with customizable options:

--- a/README.md
+++ b/README.md
@@ -4,12 +4,32 @@ Small Flask server that exposes an RSS 2.0 feed and basic REST API for the Fabri
 
 ## Tests
 
-Unit tests live in `tests/` and are run with pytest. They cover pure-Python helpers (no live SQL Server or network needed) — currently the Azure SQL retry decorator, the daily/weekly email-cadence filter, and the `ReleaseItem` parsing helpers.
+Unit tests live in `tests/` and run with pytest. They cover pure-Python helpers (no live SQL Server or network needed) — currently the Azure SQL retry decorator, the daily/weekly email-cadence filter, and the `ReleaseItem` parsing helpers.
+
+CI runs `pytest` on every push to `main` and every PR (see `.github/workflows/tests.yml`).
+
+### Run locally — virtualenv
 
 ```bash
-pip install -r requirements-dev.txt
+python -m venv .venv
+source .venv/bin/activate            # Windows: .venv\Scripts\activate
+pip install -r requirements.txt -r requirements-dev.txt
 pytest
 ```
+
+### Run locally — Docker
+
+If you do your manual testing by spinning up the Docker image, you can run the test suite inside the same container without rebuilding. Mount the working tree, install the dev deps on top of the image's existing site-packages, and invoke pytest:
+
+```bash
+docker build -t fabric-gps .
+docker run --rm -v "${PWD}:/app" fabric-gps \
+  bash -c "pip install -r requirements-dev.txt && pytest"
+```
+
+(On PowerShell, use `-v "${PWD}:/app"` as written; on `cmd.exe`, use `-v "%cd%:/app"`.)
+
+The tests don't need `SQLSERVER_CONN` or any other env var — they run entirely in-memory.
 
 ## Email Subscriptions
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+addopts = -ra --strict-markers
+filterwarnings =
+    ignore::DeprecationWarning
+norecursedirs = .venv .git migrations __pycache__ static templates db

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0.0
+freezegun>=1.5.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared test fixtures and import-path setup.
+
+Tests live in ``tests/`` but need to import top-level modules from the
+project root (e.g. ``lib.db_retry``, ``lib.release_item``,
+``weekly_email_job``). Insert the project root onto ``sys.path`` once at
+collection time so individual test files can use plain absolute imports.
+"""
+
+import os
+import sys
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)

--- a/tests/test_db_retry.py
+++ b/tests/test_db_retry.py
@@ -1,0 +1,164 @@
+"""Tests for ``lib.db_retry``: transient detection + retry decorator."""
+
+from unittest.mock import patch
+
+import pytest
+
+from lib.db_retry import (
+    is_transient_sql_azure_error,
+    retry_on_transient_errors,
+)
+
+
+class TestIsTransientSqlAzureError:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Login failed for user 'foo'",
+            "A transport-level error has occurred when receiving results from the server",
+            "Connection timeout expired",
+            "Server is busy. Please try again later.",
+            "Operation timed out",
+            "The connection is broken and recovery is not possible",
+            "[40613] Database 'x' on server 'y' is not currently available",
+            "Cannot open database requested by the login",
+            "Transaction was deadlocked on lock resources with another process",
+            "Error 10928: Resource ID : 1. The request limit for the database is N",
+        ],
+    )
+    def test_known_transient_messages_are_classified_transient(self, message):
+        exc = Exception(message)
+        assert is_transient_sql_azure_error(exc) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Invalid column name 'foo'",
+            "Permission denied on object 'release_items'",
+            "Syntax error near 'SELET'",
+            "Conversion failed when converting the nvarchar value 'abc'",
+            "Cannot insert duplicate key in object 'dbo.release_items'",
+        ],
+    )
+    def test_known_non_transient_messages_are_classified_non_transient(self, message):
+        exc = Exception(message)
+        assert is_transient_sql_azure_error(exc) is False
+
+    def test_none_returns_false(self):
+        assert is_transient_sql_azure_error(None) is False
+
+    def test_transient_codes_match_inside_longer_messages(self):
+        # 1205 = deadlock victim
+        exc = RuntimeError("pyodbc.Error: ('40001', 'Transaction (Process ID 52) ... 1205')")
+        assert is_transient_sql_azure_error(exc) is True
+
+
+class TestRetryOnTransientErrors:
+    def test_success_on_first_attempt_does_not_retry(self):
+        calls = []
+
+        @retry_on_transient_errors(max_attempts=3, initial_delay=0)
+        def op():
+            calls.append(1)
+            return "ok"
+
+        assert op() == "ok"
+        assert calls == [1]
+
+    def test_non_transient_raises_immediately_without_retry(self):
+        calls = []
+
+        @retry_on_transient_errors(max_attempts=5, initial_delay=0)
+        def op():
+            calls.append(1)
+            raise ValueError("Invalid column name 'foo'")
+
+        with pytest.raises(ValueError):
+            op()
+        assert len(calls) == 1
+
+    def test_transient_then_success_returns_value(self):
+        calls = []
+
+        @retry_on_transient_errors(max_attempts=3, initial_delay=0)
+        def op():
+            calls.append(1)
+            if len(calls) < 3:
+                raise RuntimeError("Connection timeout")
+            return "recovered"
+
+        with patch("lib.db_retry.time.sleep"):
+            assert op() == "recovered"
+        assert len(calls) == 3
+
+    def test_transient_exhausts_attempts_and_re_raises(self):
+        calls = []
+
+        @retry_on_transient_errors(max_attempts=3, initial_delay=0)
+        def op():
+            calls.append(1)
+            raise RuntimeError("Server is busy")
+
+        with patch("lib.db_retry.time.sleep"):
+            with pytest.raises(RuntimeError, match="Server is busy"):
+                op()
+        # Total attempts == max_attempts (initial + retries)
+        assert len(calls) == 3
+
+    def test_backoff_delay_grows_and_caps(self):
+        sleeps = []
+
+        @retry_on_transient_errors(
+            max_attempts=5,
+            initial_delay=1.0,
+            backoff=2.0,
+            max_delay=4.0,
+        )
+        def op():
+            raise RuntimeError("Server is busy")
+
+        # Make jitter deterministic (random.random -> 0).
+        with patch("lib.db_retry.time.sleep", side_effect=sleeps.append), \
+             patch("lib.db_retry.random.random", return_value=0.0):
+            with pytest.raises(RuntimeError):
+                op()
+
+        # 4 sleeps for 5 attempts. Delays: 1.0, 2.0, 4.0 (capped), 4.0 (capped).
+        assert sleeps == [1.0, 2.0, 4.0, 4.0]
+
+    def test_jitter_is_added_within_bounds(self):
+        sleeps = []
+
+        @retry_on_transient_errors(
+            max_attempts=2,
+            initial_delay=1.0,
+            backoff=2.0,
+            max_delay=10.0,
+        )
+        def op():
+            raise RuntimeError("Connection timeout")
+
+        with patch("lib.db_retry.time.sleep", side_effect=sleeps.append), \
+             patch("lib.db_retry.random.random", return_value=0.5):
+            with pytest.raises(RuntimeError):
+                op()
+
+        # initial_delay (1.0) + jitter (0.5 * 0.5 = 0.25) = 1.25
+        assert sleeps == [1.25]
+
+    def test_decorator_preserves_function_name_and_doc(self):
+        @retry_on_transient_errors()
+        def my_func():
+            """My docstring."""
+            return 1
+
+        assert my_func.__name__ == "my_func"
+        assert my_func.__doc__ == "My docstring."
+        assert hasattr(my_func, "__wrapped__")
+
+    def test_args_and_kwargs_passed_through(self):
+        @retry_on_transient_errors()
+        def add(a, b, multiplier=1):
+            return (a + b) * multiplier
+
+        assert add(2, 3, multiplier=4) == 20

--- a/tests/test_email_cadence.py
+++ b/tests/test_email_cadence.py
@@ -1,0 +1,118 @@
+"""Tests for ``WeeklyEmailSender._filter_by_cadence`` (H6 fix).
+
+The daily-cadence path used to live inline inside ``_get_subscriber_content``
+with no test coverage — a date-format change there would silently send
+every daily subscriber an empty digest. The logic now lives in a pure
+static helper that takes injectable ``now`` so we can deterministically
+test the cutoff boundary without freezing the clock for the whole module.
+"""
+
+from datetime import datetime
+from unittest.mock import patch  # noqa: F401  (kept for future tests)
+
+import pytest
+
+
+# Importing weekly_email_job pulls in heavy DB / opentelemetry side effects
+# only at construction time, not at import. The class itself is safe to
+# reach for the static helper.
+from weekly_email_job import WeeklyEmailSender
+
+
+def _item(last_modified, **extra):
+    base = {
+        "release_item_id": "00000000-0000-0000-0000-000000000000",
+        "feature_name": "Test feature",
+        "product_name": "Power BI",
+        "last_modified": last_modified,
+    }
+    base.update(extra)
+    return base
+
+
+class TestFilterByCadenceWeekly:
+    def test_weekly_passes_through_unchanged(self):
+        items = [_item("2026-04-01"), _item("2026-04-15"), _item(None)]
+        result = WeeklyEmailSender._filter_by_cadence(items, "weekly")
+        assert result == items
+
+    def test_none_cadence_passes_through_unchanged(self):
+        items = [_item("2026-04-01"), _item(None)]
+        result = WeeklyEmailSender._filter_by_cadence(items, None)
+        assert result == items
+
+    def test_unknown_cadence_passes_through_unchanged(self):
+        items = [_item("2026-04-01")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "monthly")
+        assert result == items
+
+    def test_returns_a_new_list_not_the_input(self):
+        items = [_item("2026-04-01")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "weekly")
+        assert result == items
+        assert result is not items
+
+
+class TestFilterByCadenceDaily:
+    NOW = datetime(2026, 4, 22, 12, 0, 0)
+    # cutoff_date = (now - 1 day).date() = 2026-04-21
+
+    def test_item_within_window_is_kept(self):
+        items = [_item("2026-04-22"), _item("2026-04-21")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert result == items
+
+    def test_item_at_exact_cutoff_is_included(self):
+        # last_modified == cutoff_date passes the >= check
+        items = [_item("2026-04-21")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert result == items
+
+    def test_older_item_is_dropped(self):
+        items = [_item("2026-04-19"), _item("2026-04-22")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert [c["last_modified"] for c in result] == ["2026-04-22"]
+
+    def test_future_dated_item_is_kept(self):
+        # Roadmap items often have future last_modified dates; never drop them.
+        items = [_item("2026-12-31")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert result == items
+
+    def test_missing_last_modified_is_dropped(self):
+        items = [_item(None), _item(""), _item("2026-04-22")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert [c["last_modified"] for c in result] == ["2026-04-22"]
+
+    def test_item_without_last_modified_key_is_dropped(self):
+        items = [{"feature_name": "no key"}, _item("2026-04-22")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert [c["last_modified"] for c in result] == ["2026-04-22"]
+
+    @pytest.mark.parametrize("bad_value", ["not-a-date", "2026/04/22", "20260422", "April 22"])
+    def test_malformed_string_is_dropped_not_crashed(self, bad_value):
+        items = [_item(bad_value), _item("2026-04-22")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert [c["last_modified"] for c in result] == ["2026-04-22"]
+
+    def test_non_string_last_modified_is_dropped_not_crashed(self):
+        # Defensive: the API contract is YYYY-MM-DD strings, but a future
+        # change shouldn't crash daily filtering — log + skip.
+        items = [_item(20260422), _item({"bad": "type"}), _item("2026-04-22")]
+        result = WeeklyEmailSender._filter_by_cadence(items, "daily", now=self.NOW)
+        assert [c["last_modified"] for c in result] == ["2026-04-22"]
+
+    def test_empty_input_returns_empty(self):
+        assert WeeklyEmailSender._filter_by_cadence([], "daily", now=self.NOW) == []
+
+    def test_default_now_is_used_when_not_provided(self):
+        # Verify the default ``now=None`` path uses the real wall clock.
+        # freezegun intercepts datetime.utcnow() regardless of import style,
+        # which is more robust than ad-hoc datetime patching.
+        from freezegun import freeze_time
+
+        items = [_item("2026-04-22"), _item("2026-04-19")]
+        with freeze_time("2026-04-22 12:00:00"):
+            result = WeeklyEmailSender._filter_by_cadence(items, "daily")
+
+        assert [c["last_modified"] for c in result] == ["2026-04-22"]

--- a/tests/test_release_item.py
+++ b/tests/test_release_item.py
@@ -1,0 +1,135 @@
+"""Tests for ``lib.release_item.ReleaseItem`` parsing helpers."""
+
+import uuid
+from datetime import date
+
+import pytest
+
+from lib.release_item import ReleaseItem
+
+
+class TestParseUuid:
+    def test_none_returns_none(self):
+        assert ReleaseItem._parse_uuid(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert ReleaseItem._parse_uuid("") is None
+
+    def test_valid_uuid_string(self):
+        s = "550e8400-e29b-41d4-a716-446655440000"
+        assert ReleaseItem._parse_uuid(s) == uuid.UUID(s)
+
+    def test_braced_uuid_string(self):
+        s = "{550e8400-e29b-41d4-a716-446655440000}"
+        assert ReleaseItem._parse_uuid(s) == uuid.UUID(s.strip("{}"))
+
+    def test_uuid_instance_passes_through(self):
+        u = uuid.uuid4()
+        assert ReleaseItem._parse_uuid(u) is u
+
+    def test_invalid_string_returns_none(self):
+        assert ReleaseItem._parse_uuid("not-a-uuid") is None
+
+
+class TestParseDate:
+    def test_none_returns_none(self):
+        assert ReleaseItem._parse_date(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert ReleaseItem._parse_date("") is None
+
+    def test_us_format(self):
+        assert ReleaseItem._parse_date("03/15/2026") == date(2026, 3, 15)
+
+    def test_iso_format(self):
+        assert ReleaseItem._parse_date("2026-03-15") == date(2026, 3, 15)
+
+    def test_iso_with_time(self):
+        # Falls through to fromisoformat path
+        assert ReleaseItem._parse_date("2026-03-15T10:30:00") == date(2026, 3, 15)
+
+    def test_date_instance_passes_through(self):
+        d = date(2026, 3, 15)
+        assert ReleaseItem._parse_date(d) is d
+
+    def test_garbage_returns_none(self):
+        assert ReleaseItem._parse_date("not a date") is None
+
+
+class TestParseBool:
+    @pytest.mark.parametrize("value", [True, "true", "True", "1", "yes", "Y", "t"])
+    def test_truthy_values(self, value):
+        assert ReleaseItem._parse_bool(value) is True
+
+    @pytest.mark.parametrize("value", [False, "false", "False", "0", "no", "N", "f"])
+    def test_falsey_values(self, value):
+        assert ReleaseItem._parse_bool(value) is False
+
+    def test_none_returns_none(self):
+        assert ReleaseItem._parse_bool(None) is None
+
+    def test_unrecognized_returns_none(self):
+        assert ReleaseItem._parse_bool("maybe") is None
+
+
+class TestParseInt:
+    def test_int_passes_through(self):
+        assert ReleaseItem._parse_int(5) == 5
+
+    def test_string_int(self):
+        assert ReleaseItem._parse_int("42") == 42
+
+    def test_none_returns_none(self):
+        assert ReleaseItem._parse_int(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert ReleaseItem._parse_int("") is None
+
+    def test_garbage_returns_none(self):
+        assert ReleaseItem._parse_int("abc") is None
+
+
+class TestFromDictAndToDict:
+    def test_round_trip_full_record(self):
+        u = uuid.uuid4()
+        product_id = uuid.uuid4()
+        d = {
+            "ReleaseItemID": str(u),
+            "FeatureName": "Direct Lake",
+            "ReleaseDate": "03/15/2026",
+            "ReleaseType": "Public Preview",
+            "ReleaseTypeValue": "1",
+            "VSOItem": "AB#12345",
+            "ReleaseStatus": "Released",
+            "ReleaseStatusValue": "2",
+            "ReleaseSemester": "2026 Wave 1",
+            "ProductID": str(product_id),
+            "ProductName": "Power BI",
+            "isPublishExternally": "true",
+            "FeatureDescription": "A new feature",
+        }
+        item = ReleaseItem.from_dict(d)
+        assert item.release_item_id == u
+        assert item.feature_name == "Direct Lake"
+        assert item.release_date == date(2026, 3, 15)
+        assert item.release_type_value == 1
+        assert item.is_publish_externally is True
+        assert item.product_id == product_id
+
+        out = item.to_dict()
+        assert out["ReleaseItemID"] == str(u)
+        assert out["ReleaseDate"] == "03/15/2026"
+        assert out["isPublishExternally"] == "true"
+
+    def test_from_dict_handles_missing_keys(self):
+        item = ReleaseItem.from_dict({})
+        assert item.feature_name is None
+        assert item.release_date is None
+        assert item.release_item_id is None
+
+    def test_to_dict_handles_none_fields(self):
+        item = ReleaseItem()
+        out = item.to_dict()
+        assert out["ReleaseItemID"] is None
+        assert out["ReleaseDate"] is None
+        assert out["isPublishExternally"] is None

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -113,6 +113,52 @@ class WeeklyEmailSender:
         raw = '|'.join(parts)
         return hashlib.sha256(raw.encode()).hexdigest()
 
+    @staticmethod
+    def _filter_by_cadence(
+        items: List[Dict[str, Any]],
+        cadence: Optional[str],
+        now: Optional[datetime] = None,
+    ) -> List[Dict[str, Any]]:
+        """Filter raw changes to only those within the cadence window.
+
+        - ``cadence == 'daily'``: keep items whose ``last_modified`` is on or
+          after ``(now - 1 day).date()``. ``/api/releases`` exposes
+          ``last_modified`` as a date-only string (``YYYY-MM-DD``), so the
+          comparison is a date-based one rather than a full timestamp.
+        - Anything else (notably ``'weekly'`` or ``None``): pass through
+          unchanged. The 7-day window is already applied upstream by the
+          ``/api/releases`` query in ``_fetch_all_changes_unfiltered``.
+
+        Items with missing or malformed ``last_modified`` are dropped from
+        the daily path (and a warning is logged for the malformed case) so
+        a single bad row can't crash the whole digest run. Both ``ValueError``
+        (bad date format) and ``TypeError`` (non-string value, e.g. an int
+        slipping through a future schema change) are handled — slightly
+        wider than the original inline ``except ValueError`` for resilience.
+
+        ``now`` is injectable for deterministic tests; defaults to
+        ``datetime.utcnow()``.
+        """
+        if cadence != 'daily':
+            return list(items)
+
+        reference = now if now is not None else datetime.utcnow()
+        cutoff_date = (reference - timedelta(days=1)).date()
+
+        filtered: List[Dict[str, Any]] = []
+        for c in items:
+            last_modified = c.get('last_modified')
+            if not last_modified:
+                continue
+            try:
+                last_modified_date = datetime.strptime(last_modified, '%Y-%m-%d').date()
+            except (ValueError, TypeError):
+                logger.warning("Skipping item with invalid last_modified value: %s", last_modified)
+                continue
+            if last_modified_date >= cutoff_date:
+                filtered.append(c)
+        return filtered
+
     def _get_subscriber_content(self, subscription: EmailSubscriptionModel):
         """Return (changes, ai_summary) for a subscriber, using per-date per-filter DB cache.
 
@@ -149,23 +195,7 @@ class WeeklyEmailSender:
         # Cache miss: filter from raw data
         items = list(self._fetch_raw_changes())
 
-        if subscription.email_cadence == 'daily':
-            # `/api/releases` exposes `last_modified` as a date-only string (`YYYY-MM-DD`),
-            # so daily filtering must use a date-based cutoff rather than a timestamp.
-            cutoff_date = (datetime.utcnow() - timedelta(days=1)).date()
-            filtered_items = []
-            for c in items:
-                last_modified = c.get('last_modified')
-                if not last_modified:
-                    continue
-                try:
-                    last_modified_date = datetime.strptime(last_modified, '%Y-%m-%d').date()
-                except ValueError:
-                    logger.warning("Skipping item with invalid last_modified value: %s", last_modified)
-                    continue
-                if last_modified_date >= cutoff_date:
-                    filtered_items.append(c)
-            items = filtered_items
+        items = self._filter_by_cadence(items, subscription.email_cadence)
 
         if subscription.product_filter:
             products = {p.strip().lower() for p in subscription.product_filter.split(',') if p.strip()}


### PR DESCRIPTION
# Test scaffold + H6 fix: extract `_filter_by_cadence` and cover the silent-failure path

First proper unit test scaffold for the project (no tests existed before). Catalyst is HIGH-priority finding **H6** from the code-quality review: the daily-cadence filter inside `weekly_email_job._get_subscriber_content` had zero coverage, and a date-format change there would silently send every daily subscriber an empty digest — the job logs success either way.

## What changed

### Scaffold
- `requirements-dev.txt` (new) — `pytest` + `freezegun`
- `pytest.ini` (new) — `testpaths=tests`, strict markers, ignore `static/`, `templates/`, `migrations/`, `db/`, `.venv/`
- `tests/__init__.py` and `tests/conftest.py` (new) — adds the project root to `sys.path` so tests can use plain absolute imports (`from lib.db_retry import …`). Standard flat-layout pattern, no `pyproject.toml` migration required
- `README.md` — added a "Tests" section showing `pip install -r requirements-dev.txt && pytest`

### H6 refactor
- `weekly_email_job.py` — extracted the daily date-cutoff loop out of `_get_subscriber_content` into a pure static helper `_filter_by_cadence(items, cadence, now=None)`. `now` is injectable so tests can pin the cutoff deterministically without freezing wall-clock time across the suite.
- The replacement is one line in `_get_subscriber_content`. Behavior is the same as before for daily and weekly with one deliberate widening: the `except` now also catches `TypeError` (in addition to `ValueError`) so a non-string `last_modified` slipping through some future schema change can't crash the entire digest run — it's logged and skipped, just like a malformed date string. This is documented in the helper docstring.

### Tests (79 total, all green in ~2s, no DB / network)
- `tests/test_db_retry.py` (25 tests) — `is_transient_sql_azure_error` (known-transient codes & phrases, known-non-transient samples, `None` handling, code matches inside larger messages); `retry_on_transient_errors` (success path, non-transient immediate raise, transient-then-success, exhaustion, exponential backoff with cap, jitter math, name/doc/`__wrapped__` preserved, args/kwargs pass-through). All `time.sleep` and `random.random` calls are mocked so the suite is deterministic and fast.
- `tests/test_email_cadence.py` (17 tests) — the H6 fix: weekly/None/unknown cadences pass through; daily includes items at exact cutoff and in the future, drops items with missing/empty/None `last_modified`, drops malformed strings (`"not-a-date"`, `"2026/04/22"`, etc.) without crashing, drops non-string values without crashing, returns a fresh list, and uses the wall clock when `now` is omitted (verified with `freezegun`).
- `tests/test_release_item.py` (37 tests) — `_parse_uuid` (None / valid / braced / instance pass-through / invalid), `_parse_date` (US `mm/dd/yyyy`, ISO, ISO with time, `date` instance pass-through, garbage), `_parse_bool` (truthy/falsey variants, garbage, None), `_parse_int` (int, string, None, empty, garbage), and `from_dict`/`to_dict` round-trip + missing-keys + None-fields.

## Reviewer feedback addressed
- The first version of `test_default_now_is_used_when_not_provided` patched `weekly_email_job.datetime` directly, which works but is brittle around the `from datetime import datetime` import style. Rewrote the test to use `freezegun.freeze_time` instead — clearer intent, less fragile.
- Documented the `ValueError` → `(ValueError, TypeError)` widening in the helper docstring as an intentional resilience improvement (not accidental drift).

## Verified
- `pytest` — 79 passed in 2.33s on first run, 1.68s on re-run
- `code-review` agent on the staged diff — no blocking issues remaining

## Out of scope (worth doing in follow-ups)
- CI integration — the existing `.github/workflows/docker-publish.yml` is build-only. Adding a test job is a small separate PR and not required to land this scaffold.
- Tests for code paths that need a live SQL Server (would need integration scaffolding).
- Tests for SQLAlchemy-heavy code in `db/db_sqlserver.py` (lower ROI than the three modules above).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
