### PR TITLE
Quick-wins batch: telemetry + sitemap hardening + bare-except fixes

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -1588,18 +1588,21 @@ def count_vector_search_releases(
 @retry_on_transient_errors(max_attempts=5, initial_delay=1.0, backoff=2.0, max_delay=60.0)
 def healthcheck(engine):
     conn = engine.raw_connection()
+    cursor = None
     try:
-        # Assuming SQL Server; call the stored proc with one parameter
         cursor = conn.cursor()
         cursor.execute("SELECT 1")
         return True
-    except:
+    except Exception:
+        # Bare except previously caught KeyboardInterrupt / SystemExit too,
+        # which could mask SIGTERM during a healthcheck poll.
         return False
     finally:
-        try:
-            cursor.close()
-        except Exception:
-            pass
+        if cursor is not None:
+            try:
+                cursor.close()
+            except Exception:
+                pass
         conn.close()
     
     

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -1,0 +1,85 @@
+"""Shared OpenTelemetry / Azure Monitor wiring for all pipeline + web entrypoints.
+
+Half of the pipeline scripts had `configure_azure_monitor` set up inline at
+module import; the other half (vectorize, match, scrape) had nothing, so they
+emitted no traces or logs to App Insights. That meant a "the vectorize step
+took 4 minutes longer this week" question had no answer.
+
+Centralizing here means:
+
+- One place to bump SDK config (sampling, live metrics, exporters).
+- Every script gets the same telemetry-disabled-in-development behavior.
+- Tests can trivially exercise the gating logic without touching the network.
+
+Usage at the top of each entrypoint::
+
+    from lib.telemetry import init_telemetry
+
+    logger = init_telemetry("fabric-gps-vectorize")
+
+The function is a no-op (apart from setting the service name and creating
+the logger) when ``APPLICATIONINSIGHTS_CONNECTION_STRING`` is unset or
+``CURRENT_ENVIRONMENT == 'development'``.
+"""
+
+import logging
+import os
+from typing import Optional
+
+
+def _should_configure_azure_monitor() -> bool:
+    """Return True only when telemetry is wired in production.
+
+    Mirrors the gating used by ``server.py`` and ``get_current_releases.py``
+    so the behavior is identical across entrypoints.
+    """
+    if not os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING"):
+        return False
+    if os.getenv("CURRENT_ENVIRONMENT") == "development":
+        return False
+    return True
+
+
+def init_telemetry(
+    service_name: str,
+    logger_name: Optional[str] = None,
+    *,
+    enable_live_metrics: bool = True,
+) -> logging.Logger:
+    """Configure Azure Monitor + return a stream-handled OTel logger.
+
+    Args:
+        service_name: Value to set for ``OTEL_SERVICE_NAME``. Each pipeline
+            entrypoint should pick a distinct name (e.g.
+            ``"fabric-gps-vectorize"``) so traces partition cleanly in
+            App Insights.
+        logger_name: Name to use for the returned logger. Defaults to
+            ``f"{service_name}.opentelemetry"`` to match the pre-existing
+            convention in ``server.py`` and ``get_current_releases.py``.
+        enable_live_metrics: Forwarded to ``configure_azure_monitor``.
+
+    Returns:
+        A ``logging.Logger`` with a ``StreamHandler`` attached and INFO
+        level set. Safe to use whether or not Azure Monitor was actually
+        configured (in development the same logger still prints to stderr).
+    """
+    os.environ["OTEL_SERVICE_NAME"] = service_name
+
+    name = logger_name or f"{service_name}.opentelemetry"
+
+    if _should_configure_azure_monitor():
+        # Imported lazily so unit tests / dev environments without the
+        # azure-monitor-opentelemetry distribution can still import this
+        # module to check the gating logic.
+        from azure.monitor.opentelemetry import configure_azure_monitor
+
+        configure_azure_monitor(
+            logger_name=name,
+            enable_live_metrics=enable_live_metrics,
+        )
+
+    logger = logging.getLogger(name)
+    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.INFO)
+    return logger

--- a/match_releases_to_blogs.py
+++ b/match_releases_to_blogs.py
@@ -13,6 +13,7 @@ from openai import AzureOpenAI
 import json
 
 from lib.db_retry import retry_on_transient_errors, is_transient_sql_azure_error
+from lib.telemetry import init_telemetry
 
 # Configure logging
 logging.basicConfig(
@@ -20,6 +21,9 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+# Wire Azure Monitor for the pipeline run (no-op in development).
+init_telemetry("fabric-gps-match")
 
 
 class ReleaseBlogMatcher:

--- a/scrape_fabric_blog.py
+++ b/scrape_fabric_blog.py
@@ -22,6 +22,7 @@ import xml.etree.ElementTree as ET
 import html
 
 from lib.db_retry import retry_on_transient_errors
+from lib.telemetry import init_telemetry
 
 # Configure logging
 logging.basicConfig(
@@ -29,6 +30,9 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+# Wire Azure Monitor for the pipeline run (no-op in development).
+init_telemetry("fabric-gps-blog-scraper")
 
 
 class FabricBlogScraper:

--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ import urllib.parse
 import threading
 import logging
 from datetime import datetime, date, time, timezone
+from types import SimpleNamespace
 from typing import Optional, List
 
 from flask import Flask, request, Response, jsonify, render_template, redirect, send_from_directory, url_for
@@ -1245,8 +1246,11 @@ def verify_email_page():
                     release = session.get(ReleaseItemModel, verification.pending_watch_release_id)
                     if release:
                         watch_feature_name = release.feature_name
-    except Exception:
-        pass
+    except Exception as e:
+        # Surface, but don't fail the page — the GET is purely informational
+        # (cadence + watch-feature label). The user can still POST the form
+        # to actually verify. Logging means a regression doesn't go silent.
+        otelLogger.warning("verify-email context lookup failed: %s", e)
     return render_template('verify_email.html', pending=True, token=token,
                            cadence=cadence, watch_feature_name=watch_feature_name)
 
@@ -1643,49 +1647,87 @@ def indexnow_key_file(key):
     return Response(INDEXNOW_API_KEY, mimetype="text/plain")
 
 
+_STATIC_SITEMAP_PAGES = (
+    {"loc": "/",          "priority": "1.0", "changefreq": "hourly"},
+    {"loc": "/changelog", "priority": "0.9", "changefreq": "hourly"},
+    {"loc": "/about",     "priority": "0.7", "changefreq": "monthly"},
+    {"loc": "/endpoints", "priority": "0.6", "changefreq": "monthly"},
+    {"loc": "/subscribe", "priority": "0.6", "changefreq": "monthly"},
+    {"loc": "/rss",       "priority": "0.5", "changefreq": "hourly"},
+)
+
+
+def _render_sitemap_xml(base_url: str, release_rows) -> str:
+    """Render the sitemap XML body for the static pages plus per-release URLs.
+
+    ``release_rows`` is any iterable of objects with ``release_item_id`` and
+    ``last_modified`` attributes (e.g. SQLAlchemy rows or test stubs). All
+    interpolated values are XML-escaped — today ``release_item_id`` is a
+    Fabric API GUID with no XML-special characters, so this is
+    defense-in-depth, not a bug fix.
+    """
+    parts = []
+    for p in _STATIC_SITEMAP_PAGES:
+        parts.append(
+            "  <url>\n"
+            f"    <loc>{escape(base_url + p['loc'])}</loc>\n"
+            f"    <changefreq>{escape(p['changefreq'])}</changefreq>\n"
+            f"    <priority>{escape(p['priority'])}</priority>\n"
+            "  </url>\n"
+        )
+    for r in release_rows:
+        lastmod = ""
+        if r.last_modified and hasattr(r.last_modified, 'strftime'):
+            lastmod = f"\n    <lastmod>{escape(r.last_modified.strftime('%Y-%m-%d'))}</lastmod>"
+        parts.append(
+            "  <url>\n"
+            f"    <loc>{escape(f'{base_url}/release/{r.release_item_id}')}</loc>{lastmod}\n"
+            "    <changefreq>weekly</changefreq>\n"
+            "    <priority>0.8</priority>\n"
+            "  </url>\n"
+        )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        + ''.join(parts)
+        + '</urlset>\n'
+    )
+
+
 @app.get("/sitemap.xml")
 def sitemap_xml():
-    """Serve a dynamic XML sitemap for search engines."""
-    base = EMAIL_BASE_URL
-    pages = [
-        {"loc": "/",          "priority": "1.0", "changefreq": "hourly"},
-        {"loc": "/changelog", "priority": "0.9", "changefreq": "hourly"},
-        {"loc": "/about",     "priority": "0.7", "changefreq": "monthly"},
-        {"loc": "/endpoints", "priority": "0.6", "changefreq": "monthly"},
-        {"loc": "/subscribe", "priority": "0.6", "changefreq": "monthly"},
-        {"loc": "/rss",       "priority": "0.5", "changefreq": "hourly"},
-    ]
-    urls = ""
-    for p in pages:
-        urls += f"""  <url>
-    <loc>{base}{p["loc"]}</loc>
-    <changefreq>{p["changefreq"]}</changefreq>
-    <priority>{p["priority"]}</priority>
-  </url>
-"""
-    # Add individual release pages
+    """Serve a dynamic XML sitemap for search engines.
+
+    Uses ``_make_cached_response`` so Front Door (and well-behaved bots) can
+    cache for an hour rather than re-rendering the full release list on
+    every Bing/Google miss. The data only changes hourly via the refresh
+    job, so a one-hour TTL aligns with the freshness window.
+    """
     engine = get_engine()
     SessionLocal = sessionmaker(bind=engine, future=True)
     with SessionLocal() as session:
         releases = session.query(
             ReleaseItemModel.release_item_id,
-            ReleaseItemModel.last_modified
+            ReleaseItemModel.last_modified,
         ).filter(ReleaseItemModel.active == True).all()
-        for r in releases:
-            lastmod = ""
-            if r.last_modified and hasattr(r.last_modified, 'strftime'):
-                lastmod = f"\n    <lastmod>{r.last_modified.strftime('%Y-%m-%d')}</lastmod>"
-            urls += f"""  <url>
-    <loc>{base}/release/{r.release_item_id}</loc>{lastmod}
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-"""
-    body = f"""<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{urls}</urlset>
-"""
-    return Response(body, mimetype="application/xml")
+        # Materialize plain rows + grab last-modified before the session
+        # closes so the cache helper can set a data-derived Last-Modified
+        # header (and so we don't pass detached ORM rows around).
+        release_rows = [
+            SimpleNamespace(
+                release_item_id=r.release_item_id,
+                last_modified=r.last_modified,
+            )
+            for r in releases
+        ]
+        last_modified = _max_last_modified(release_rows)
+
+    body = _render_sitemap_xml(EMAIL_BASE_URL, release_rows)
+    return _make_cached_response(
+        body,
+        mimetype="application/xml; charset=utf-8",
+        last_modified=last_modified,
+    )
 
 
 @app.get("/healthcheck")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,17 @@ Tests live in ``tests/`` but need to import top-level modules from the
 project root (e.g. ``lib.db_retry``, ``lib.release_item``,
 ``weekly_email_job``). Insert the project root onto ``sys.path`` once at
 collection time so individual test files can use plain absolute imports.
+
+Also forces ``CURRENT_ENVIRONMENT=development`` before any test module is
+imported so production-only env-var checks (ACS resource ID, HTTPS base
+URL, App Insights connection string) don't prevent ``import server`` /
+``import weekly_email_job`` in tests.
 """
 
 import os
 import sys
+
+os.environ.setdefault("CURRENT_ENVIRONMENT", "development")
 
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 if _PROJECT_ROOT not in sys.path:

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,91 @@
+"""Tests for sitemap rendering — XML escape (M11) and structure.
+
+Importing ``server`` requires ``CURRENT_ENVIRONMENT=development`` (which
+``conftest.py`` sets) so the production-only env-var checks don't trip.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from server import _render_sitemap_xml, _STATIC_SITEMAP_PAGES
+
+
+def _row(release_item_id, last_modified=None):
+    return SimpleNamespace(release_item_id=release_item_id, last_modified=last_modified)
+
+
+class TestRenderSitemapXml:
+    def test_returns_well_formed_xml(self):
+        body = _render_sitemap_xml("https://example.com", [_row("guid-1", date(2026, 4, 22))])
+        # ElementTree raises on malformed XML.
+        ET.fromstring(body)
+
+    def test_includes_static_pages(self):
+        body = _render_sitemap_xml("https://example.com", [])
+        for p in _STATIC_SITEMAP_PAGES:
+            assert f"https://example.com{p['loc']}" in body
+
+    def test_includes_release_pages(self):
+        rows = [_row("guid-aaa", date(2026, 4, 1)), _row("guid-bbb", date(2026, 4, 2))]
+        body = _render_sitemap_xml("https://example.com", rows)
+        assert "https://example.com/release/guid-aaa" in body
+        assert "https://example.com/release/guid-bbb" in body
+        assert "<lastmod>2026-04-01</lastmod>" in body
+        assert "<lastmod>2026-04-02</lastmod>" in body
+
+    def test_release_id_with_xml_special_chars_is_escaped(self):
+        # Defense-in-depth: today release_item_id is a Fabric API GUID, so
+        # this can't happen in practice. But the previous code wrote the ID
+        # straight into XML, which would corrupt the document if a future
+        # ID format ever included &, <, >, or ".
+        evil_id = 'a&b<c>d"e'
+        body = _render_sitemap_xml("https://example.com", [_row(evil_id)])
+
+        # Body must still parse as XML.
+        root = ET.fromstring(body)
+
+        # Find the offending <loc>; it should contain the literal evil ID
+        # *after* parsing (i.e. the raw bytes are escaped).
+        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        locs = [el.text for el in root.findall(".//sm:loc", ns)]
+        assert f"https://example.com/release/{evil_id}" in locs
+
+        # And the raw body must NOT contain the unescaped < / > / & sequence
+        # that would have broken the XML.
+        assert "<c>" not in body
+        assert 'a&b' not in body  # would be a&amp;b after escape
+
+    def test_base_url_with_xml_special_chars_is_escaped(self):
+        # Equally defensive — BASE_URL is operator-controlled, but if it
+        # ever held an ampersand (e.g. from a misconfigured query string)
+        # the XML would have broken silently before this fix.
+        body = _render_sitemap_xml("https://example.com/?a=1&b=2", [])
+        ET.fromstring(body)  # must still parse
+        assert "&amp;" in body
+
+    def test_row_with_no_last_modified_omits_lastmod_tag(self):
+        body = _render_sitemap_xml("https://example.com", [_row("guid", last_modified=None)])
+        # The release URL must still be present, but no lastmod element for it.
+        assert "https://example.com/release/guid" in body
+        # Static pages don't emit lastmod either, so a count of 0 is correct.
+        assert "<lastmod>" not in body
+
+    def test_empty_release_list_still_includes_static_pages(self):
+        body = _render_sitemap_xml("https://example.com", [])
+        root = ET.fromstring(body)
+        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        urls = root.findall(".//sm:url", ns)
+        assert len(urls) == len(_STATIC_SITEMAP_PAGES)
+
+    def test_static_pages_have_priority_and_changefreq(self):
+        body = _render_sitemap_xml("https://example.com", [])
+        root = ET.fromstring(body)
+        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        urls = root.findall(".//sm:url", ns)
+        for url in urls:
+            assert url.find("sm:loc", ns) is not None
+            assert url.find("sm:changefreq", ns) is not None
+            assert url.find("sm:priority", ns) is not None

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,128 @@
+"""Tests for ``lib.telemetry`` — Azure Monitor wiring with safe defaults."""
+
+import logging
+import os
+import sys
+
+import pytest
+
+from lib import telemetry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Tests should not depend on the developer's actual env vars."""
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+    monkeypatch.delenv("CURRENT_ENVIRONMENT", raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _strip_stream_handlers():
+    """``init_telemetry`` adds a single StreamHandler per logger and is
+    careful not to duplicate, but tests create loggers under several names
+    and we want each test to start from a clean slate."""
+    yield
+    for name in list(logging.Logger.manager.loggerDict.keys()):
+        if "fabric-gps-test" in name or name.startswith("svc") or name == "custom.name":
+            lg = logging.getLogger(name)
+            lg.handlers.clear()
+
+
+def test_init_telemetry_sets_service_name():
+    telemetry.init_telemetry("fabric-gps-test")
+
+    assert os.environ["OTEL_SERVICE_NAME"] == "fabric-gps-test"
+
+
+def test_init_telemetry_returns_logger_with_stream_handler():
+    logger = telemetry.init_telemetry("fabric-gps-test")
+
+    assert isinstance(logger, logging.Logger)
+    assert logger.level == logging.INFO
+    assert any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
+
+
+def test_init_telemetry_default_logger_name():
+    logger = telemetry.init_telemetry("fabric-gps-test")
+
+    assert logger.name == "fabric-gps-test.opentelemetry"
+
+
+def test_init_telemetry_custom_logger_name():
+    logger = telemetry.init_telemetry("fabric-gps-test", logger_name="custom.name")
+
+    assert logger.name == "custom.name"
+
+
+def test_init_telemetry_skips_azure_monitor_when_no_connection_string(monkeypatch):
+    """Without APPLICATIONINSIGHTS_CONNECTION_STRING set, Azure Monitor must
+    not be configured — otherwise local dev runs would fail trying to ship
+    spans to a non-existent endpoint."""
+    monkeypatch.setattr(telemetry, "_should_configure_azure_monitor", lambda: False)
+
+    # If gating were broken and the lazy import ran, monkey-injecting a
+    # poison fake_configure would surface the bug.
+    fake_module = type(sys)("azure.monitor.opentelemetry")
+
+    def explode(**kwargs):
+        raise AssertionError("configure_azure_monitor must NOT be called when gated off")
+
+    fake_module.configure_azure_monitor = explode
+    monkeypatch.setitem(sys.modules, "azure.monitor.opentelemetry", fake_module)
+
+    telemetry.init_telemetry("svc")  # must not raise
+
+
+def test_init_telemetry_calls_azure_monitor_when_gated_on(monkeypatch):
+    """When the gate returns True, ``configure_azure_monitor`` must be
+    invoked with the resolved logger name and live-metrics flag."""
+    monkeypatch.setattr(telemetry, "_should_configure_azure_monitor", lambda: True)
+
+    captured = {}
+
+    def fake_configure(**kwargs):
+        captured.update(kwargs)
+
+    fake_module = type(sys)("azure.monitor.opentelemetry")
+    fake_module.configure_azure_monitor = fake_configure
+    monkeypatch.setitem(sys.modules, "azure.monitor.opentelemetry", fake_module)
+
+    telemetry.init_telemetry("svc", enable_live_metrics=False)
+
+    assert captured == {
+        "logger_name": "svc.opentelemetry",
+        "enable_live_metrics": False,
+    }
+
+
+def test_should_configure_returns_false_in_development(monkeypatch):
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "Endpoint=https://x")
+    monkeypatch.setenv("CURRENT_ENVIRONMENT", "development")
+
+    assert telemetry._should_configure_azure_monitor() is False
+
+
+def test_should_configure_returns_false_without_connection_string(monkeypatch):
+    monkeypatch.setenv("CURRENT_ENVIRONMENT", "production")
+
+    assert telemetry._should_configure_azure_monitor() is False
+
+
+def test_should_configure_returns_true_in_production_with_connection_string(monkeypatch):
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "Endpoint=https://x")
+    monkeypatch.setenv("CURRENT_ENVIRONMENT", "production")
+
+    assert telemetry._should_configure_azure_monitor() is True
+
+
+def test_init_telemetry_does_not_duplicate_stream_handler():
+    """Calling init_telemetry twice with the same logger_name must not stack
+    StreamHandlers — otherwise log lines would print N times in long-running
+    processes."""
+    logger = telemetry.init_telemetry("svc-a")
+    telemetry.init_telemetry("svc-a")
+
+    stream_handlers = [h for h in logger.handlers if isinstance(h, logging.StreamHandler)]
+    assert len(stream_handlers) == 1

--- a/vectorize_blog_posts.py
+++ b/vectorize_blog_posts.py
@@ -13,6 +13,7 @@ import pyodbc
 from openai import AzureOpenAI
 
 from lib.db_retry import retry_on_transient_errors
+from lib.telemetry import init_telemetry
 
 # Configure logging
 logging.basicConfig(
@@ -20,6 +21,9 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+# Wire Azure Monitor for the pipeline run (no-op in development).
+init_telemetry("fabric-gps-vectorize")
 
 
 class BlogVectorizer:

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -699,14 +699,14 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
             if change.get('release_date'):
                 try:
                     release_date = datetime.strptime(change['release_date'], '%Y-%m-%d').strftime('%B %d, %Y')
-                except:
+                except Exception:
                     release_date = change['release_date']
             
             modified_date = 'Unknown'
             if change.get('last_modified'):
                 try:
                     modified_date = datetime.strptime(change['last_modified'], '%Y-%m-%d').strftime('%B %d, %Y')
-                except:
+                except Exception:
                     modified_date = change['last_modified']
             
             text_parts.extend([


### PR DESCRIPTION
## Summary

Quick-wins batch from the code-quality review — 5 medium-priority findings, one PR. Each change is small but they share a "defensive hardening / observability" theme, so bundling them keeps review overhead down.

| ID | Area | Change |
|---|---|---|
| **M7** | Observability | Centralize Azure Monitor / OpenTelemetry wiring in new `lib/telemetry.py`. Wire it into the 3 "dark" pipeline scripts (`vectorize_blog_posts.py`, `match_releases_to_blogs.py`, `scrape_fabric_blog.py`) which previously emitted no traces or logs to App Insights. |
| **M10** | Error handling | Replace 3 bare `except:` clauses with `except Exception:` so `KeyboardInterrupt` / `SystemExit` aren't silently swallowed. Sites: `db/db_sqlserver.py` healthcheck (1) + `weekly_email_job.py` text-email date formatting (2). |
| **M11** | Defense-in-depth | XML-escape the `release_item_id` and base URL interpolated into `/sitemap.xml`. Today the IDs are Fabric API GUIDs and the base URL is operator-controlled, so this is purely defensive — but the previous code wrote them straight into XML. |
| **M12** | Caching | Wrap the `/sitemap.xml` response in `_make_cached_response` so Front Door (and well-behaved bots) can cache for 1 hour, matching the RSS feed and other API responses. The data only changes hourly. |
| **M16** | Observability | Replace `except Exception: pass` in `verify_email_page` GET branch with a logged warning so future "why did the verify page render with empty context?" investigations have a breadcrumb. |

## Notes

- `lib/telemetry.py` lazy-imports `azure.monitor.opentelemetry` inside the gate so unit tests in dev environments without the dependency can still import the module to check gating logic.
- The sitemap render was extracted into a pure `_render_sitemap_xml(base_url, release_rows)` helper so M11 (escape) and M12 (structure) can be unit-tested without standing up the DB.
- `release_rows` are materialized into `SimpleNamespace` instances inside the SQLAlchemy session so the helper isn't coupled to detached ORM rows and tests can pass plain stubs.

## Tests

Per the new copilot test-coverage policy:

- `tests/test_telemetry.py` — 10 tests: `_should_configure_azure_monitor` truth table (no connection string / dev / prod+string), `init_telemetry` sets `OTEL_SERVICE_NAME`, returns INFO logger with single `StreamHandler` (no duplication on repeat call), default vs. custom logger name, calls `configure_azure_monitor` only when gated on (with a fake module injected via `sys.modules`).
- `tests/test_sitemap.py` — 8 tests: well-formed XML, all static pages present, release pages present with `lastmod`, XML-special chars in `release_item_id` and base URL are escaped (and the body still parses), missing `last_modified` omits the `lastmod` tag, empty release list still emits static pages, every URL has the required child elements.
- M10 (bare except) and M16 (log instead of swallow) don't have dedicated unit tests — they're literal one-line behavior changes whose only observable effect is "different exception types propagate" and "a warning line appears in logs". Calling that out per the new policy's "if a change genuinely has no testable behavior" carve-out.

`tests/conftest.py` now sets `CURRENT_ENVIRONMENT=development` before any test module is imported so production-only env-var checks (ACS resource ID, HTTPS base URL) don't prevent `import server` in tests.

Total: **97 passing** (79 existing + 18 new), runs in ~2s with no DB / network / secrets.

## Verification

- Code-review sub-agent reviewed the staged diff — no issues surfaced.
- `pytest` green locally on Python 3.12.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
