### PR TITLE
DB consistency: session_scope + release-field spec + vector WHERE builder + expunge convention

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -3,8 +3,10 @@ import json
 import uuid
 import hashlib
 from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime, date, timedelta
-from typing import Iterable, Any, Tuple, Dict
+from typing import Iterable, Any, Tuple, Dict, Callable, Iterator
 import urllib.parse
 import secrets
 import logging
@@ -14,7 +16,7 @@ from sqlalchemy import (
     create_engine, Column, String, Integer, Date, DateTime, Boolean, Text, MetaData, func, select, or_, delete, update, text
 )
 from typing import Iterable, Any, Tuple, Dict, Optional, List
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
 
 # Retry decorator lives in lib/db_retry.py so raw-pyodbc pipeline scripts
 # can share the same Azure-SQL transient-error detection.
@@ -175,6 +177,45 @@ def make_engine(conn_str: str | None = None):
     return create_engine(sanitized_conn, fast_executemany=True, future=True, pool_pre_ping=True, pool_recycle=3600)
 
 
+# ---------------------------------------------------------------------------
+# Session lifecycle
+#
+# Historical state: every public function in this module (plus ~6 sites in
+# server.py and 3 in weekly_email_job.py) constructed its own ``SessionLocal
+# = sessionmaker(bind=engine, future=True)`` line before opening a session.
+# That meant any future change to session config (``expire_on_commit``,
+# ``autoflush``, etc.) had to be made in 30+ places, and the duplicated
+# noise made it harder to see what each function actually did.
+#
+# ``session_scope(engine)`` is a *lifecycle-only* context manager: it opens
+# a Session bound to ``engine`` and closes it on exit. It deliberately does
+# **not** begin/commit a transaction — call sites that want one still wrap
+# their work in ``with session.begin():`` exactly as before.
+#
+# Detached-row convention: any function in this module that returns ORM
+# model instances (``ReleaseItemModel``, ``EmailSubscriptionModel``,
+# ``FeatureWatchModel``, ``EmailVerificationModel``) MUST call
+# ``session.expunge_all()`` (or ``session.expunge(obj)``) before the
+# session closes. Otherwise the caller can hit ``DetachedInstanceError``
+# the first time it touches an unloaded relationship. Functions that
+# return plain dicts or scalars don't need to expunge.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def session_scope(engine) -> Iterator[Session]:
+    """Open a Session bound to *engine*, yield it, and close on exit.
+
+    Construction of ``sessionmaker`` is intentionally not memoized: it's a
+    cheap, hash-table-shaped object, and caching it by engine identity
+    introduced more correctness concerns (test engines retained forever,
+    id-reuse bugs) than it solved.
+    """
+    factory = sessionmaker(bind=engine, future=True)
+    with factory() as session:
+        yield session
+
+
 @retry_on_transient_errors(max_attempts=5, initial_delay=1.0, backoff=2.0, max_delay=30.0)
 def init_db(engine):
     Base.metadata.create_all(engine)
@@ -234,45 +275,110 @@ def _compute_row_hash(payload: Dict[str, Any]) -> str:
     return hashlib.sha256(j.encode("utf-8")).hexdigest()
 
 
+# ---------------------------------------------------------------------------
+# Release-field source of truth
+#
+# Both ``_normalize_for_hash`` and ``_map_to_model_kwargs`` need to look up
+# the same field on each incoming Fabric API item, but the API uses
+# PascalCase (``FeatureName``) while the SQLAlchemy model uses snake_case
+# (``feature_name``). Previously the two helpers each carried their own
+# parallel list of pairs — a renaming refactor that touched only one of
+# them would silently invalidate every row hash, causing every roadmap
+# item to re-vectorize on the next run.
+#
+# The transforms differ slightly between the two contexts (the hash
+# stringifies dates and treats ``None`` as ``""`` for free-text fields so
+# that "blank → blank" doesn't churn the hash; the model preserves real
+# types and ``None``s). Encoding both transforms on a single spec keeps
+# the pair-of-names canonical while letting each side stay honest about
+# its needs.
+#
+# ``release_item_id`` is intentionally NOT in this list: it identifies the
+# row but is not part of the row's *content*, so it must never enter the
+# hash. ``_map_to_model_kwargs`` adds it explicitly.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ReleaseFieldSpec:
+    api_name: str        # PascalCase, the key used both in the Fabric API and in the hash payload
+    model_attr: str      # snake_case, the ReleaseItemModel attribute name
+    hash_transform: Callable[[Any], Any] = field(default=lambda v: v)
+    model_transform: Callable[[Any], Any] = field(default=lambda v: v)
+
+
+def _hash_date(v):
+    d = _to_date(v)
+    return d.isoformat() if d else None
+
+
+def _str_or_none(v):
+    return str(v) if v else None
+
+
+_RELEASE_FIELDS: List[_ReleaseFieldSpec] = [
+    # Free-text fields: hash treats None as "" so a NULL→"" UI cleanup
+    # doesn't churn the hash. Model preserves real None.
+    _ReleaseFieldSpec("FeatureName", "feature_name",
+                      hash_transform=lambda v: v or ""),
+    _ReleaseFieldSpec("FeatureDescription", "feature_description",
+                      hash_transform=lambda v: v or ""),
+
+    # Date: hash uses ISO string for stable JSON; model uses real date.
+    _ReleaseFieldSpec("ReleaseDate", "release_date",
+                      hash_transform=_hash_date,
+                      model_transform=_to_date),
+
+    # Pass-through string fields.
+    _ReleaseFieldSpec("ReleaseType", "release_type"),
+    _ReleaseFieldSpec("ReleaseStatus", "release_status"),
+    _ReleaseFieldSpec("ReleaseSemester", "release_semester"),
+    _ReleaseFieldSpec("VSOItem", "vso_item"),
+    _ReleaseFieldSpec("ProductName", "product_name"),
+
+    # Numeric fields share the same transform on both sides.
+    _ReleaseFieldSpec("ReleaseTypeValue", "release_type_value",
+                      hash_transform=_to_int, model_transform=_to_int),
+    _ReleaseFieldSpec("ReleaseStatusValue", "release_status_value",
+                      hash_transform=_to_int, model_transform=_to_int),
+
+    # Mixed: ProductID arrives as int but persists as str.
+    _ReleaseFieldSpec("ProductID", "product_id",
+                      hash_transform=_str_or_none, model_transform=_str_or_none),
+
+    # Bool with multiple truthy spellings.
+    _ReleaseFieldSpec("isPublishExternally", "is_publish_externally",
+                      hash_transform=_to_bool, model_transform=_to_bool),
+]
+
+
 def _normalize_for_hash(item: Any) -> Dict[str, Any]:
+    """Build a stable dict of content fields used to compute ``row_hash``.
+
+    Excludes ``release_item_id``, ``last_modified``, and ``row_hash`` itself.
+    Field names are intentionally PascalCase so the on-disk hash stays
+    backward-compatible with rows hashed before this refactor.
     """
-    Build a stable dict of fields that indicate content for the row.
-    Excludes last_modified and row_hash.
-    """
-    rd = _to_date(_get(item, "ReleaseDate", "release_date"))
     return {
-        "FeatureName": _get(item, "FeatureName", "feature_name") or "",
-        "ReleaseDate": rd.isoformat() if rd else None,
-        "ReleaseType": _get(item, "ReleaseType", "release_type"),
-        "ReleaseTypeValue": _to_int(_get(item, "ReleaseTypeValue", "release_type_value")),
-        "VSOItem": _get(item, "VSOItem", "vso_item"),
-        "ReleaseStatus": _get(item, "ReleaseStatus", "release_status"),
-        "ReleaseStatusValue": _to_int(_get(item, "ReleaseStatusValue", "release_status_value")),
-        "ReleaseSemester": _get(item, "ReleaseSemester", "release_semester"),
-        "ProductID": str(_get(item, "ProductID", "product_id")) if _get(item, "ProductID", "product_id") else None,
-        "ProductName": _get(item, "ProductName", "product_name"),
-        "isPublishExternally": _to_bool(_get(item, "isPublishExternally", "is_publish_externally")),
-        "FeatureDescription": _get(item, "FeatureDescription", "feature_description") or "",
+        spec.api_name: spec.hash_transform(_get(item, spec.api_name, spec.model_attr))
+        for spec in _RELEASE_FIELDS
     }
 
 
 def _map_to_model_kwargs(item: Any) -> Dict[str, Any]:
-    rd = _to_date(_get(item, "ReleaseDate", "release_date"))
-    return {
-        "release_item_id": str(_get(item, "ReleaseItemID", "release_item_id") or uuid.uuid4()),
-        "feature_name": _get(item, "FeatureName", "feature_name"),
-        "release_date": rd,
-        "release_type": _get(item, "ReleaseType", "release_type"),
-        "release_type_value": _to_int(_get(item, "ReleaseTypeValue", "release_type_value")),
-        "vso_item": _get(item, "VSOItem", "vso_item"),
-        "release_status": _get(item, "ReleaseStatus", "release_status"),
-        "release_status_value": _to_int(_get(item, "ReleaseStatusValue", "release_status_value")),
-        "release_semester": _get(item, "ReleaseSemester", "release_semester"),
-        "product_id": str(_get(item, "ProductID", "product_id")) if _get(item, "ProductID", "product_id") else None,
-        "product_name": _get(item, "ProductName", "product_name"),
-        "is_publish_externally": _to_bool(_get(item, "isPublishExternally", "is_publish_externally")),
-        "feature_description": _get(item, "FeatureDescription", "feature_description"),
+    """Build kwargs for ``ReleaseItemModel(**...)``.
+
+    Adds ``release_item_id`` (which is intentionally absent from
+    ``_RELEASE_FIELDS`` so it can't accidentally enter the hash).
+    """
+    kwargs = {
+        spec.model_attr: spec.model_transform(_get(item, spec.api_name, spec.model_attr))
+        for spec in _RELEASE_FIELDS
     }
+    kwargs["release_item_id"] = str(
+        _get(item, "ReleaseItemID", "release_item_id") or uuid.uuid4()
+    )
+    return kwargs
 
 
 @retry_on_transient_errors(max_attempts=5, initial_delay=1.0, backoff=2.0, max_delay=60.0)
@@ -283,11 +389,10 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
     Returns counts: {'inserted': n, 'updated': m, 'unchanged': k, 'changed_ids': [...]}
     This function is retried on transient SQL/Azure connection errors.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
     inserted = updated = unchanged = 0
     changed_ids = []
 
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             for item in items:
                 row_values = _map_to_model_kwargs(item)
@@ -348,11 +453,10 @@ def deactivate_missing_releases(engine, current_ids: set) -> Dict[str, int]:
 
     Returns counts: ``{'deactivated': n, 'already_inactive': m, 'deactivated_ids': [...]}``.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
     deactivated = already_inactive = 0
     deactivated_ids = []
 
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             # Determine if this is the first run by checking for any inactive rows
             has_inactive = session.scalar(
@@ -421,7 +525,6 @@ def get_recently_modified_releases(
     ``sort`` must be one of ``VALID_SORT_OPTIONS`` (default ``"last_modified"``).
     Only active releases are returned unless *include_inactive* is True.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
 
     stmt = select(ReleaseItemModel)
     filters = []
@@ -460,8 +563,11 @@ def get_recently_modified_releases(
         stmt = stmt.offset(offset)
     if limit is not None:
         stmt = stmt.limit(limit)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         rows = session.scalars(stmt).all()
+        # Detach so callers can safely use the rows after the session closes
+        # (matches the convention in get_active_subscriptions et al.).
+        session.expunge_all()
     return rows
 
 @retry_on_transient_errors(max_attempts=5, initial_delay=1.0, backoff=2.0, max_delay=60.0)
@@ -475,7 +581,6 @@ def count_recently_modified_releases(
     include_inactive: bool = False,
 ) -> int:
     """Return total count of releases matching filters/search."""
-    SessionLocal = sessionmaker(bind=engine, future=True)
     stmt = select(func.count()).select_from(ReleaseItemModel)
     filters = []
     if not include_inactive:
@@ -503,7 +608,7 @@ def count_recently_modified_releases(
             )
     if filters:
         stmt = stmt.where(*filters)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         total = session.scalar(stmt) or 0
     return int(total)
 
@@ -515,7 +620,6 @@ def get_distinct_values(engine, column_name: str, limit: Optional[int] = None) -
     Normalization groups values case-insensitively and trims whitespace.
     Returns a representative original value per group (MIN for stable display).
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
 
     # Validate requested column exists on the model
     if not hasattr(ReleaseItemModel, column_name):
@@ -536,7 +640,7 @@ def get_distinct_values(engine, column_name: str, limit: Optional[int] = None) -
     if limit is not None:
         stmt = stmt.limit(limit)
 
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         values = session.scalars(stmt).all()
 
     # Coerce to trimmed strings and drop empties
@@ -818,11 +922,10 @@ def rotate_unsubscribe_token(engine, current_token: str) -> Optional[str]:
     Callers should not rotate when resolution went via the history table —
     that's already a stale link being reused via the grace window.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
     now = datetime.utcnow()
     grace_expires = now + timedelta(days=_UNSUBSCRIBE_TOKEN_GRACE_DAYS)
 
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             sub = session.scalar(
                 select(EmailSubscriptionModel)
@@ -916,9 +1019,7 @@ def create_email_subscription(engine, email: str, filters: Optional[Dict[str, st
     """
     if cadence not in ('daily', 'weekly'):
         cadence = 'weekly'
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             # Check if subscription already exists
             existing = session.scalar(
@@ -986,9 +1087,7 @@ def create_watch_verification(engine, email: str, release_item_id: str) -> Tuple
 
     Raises EmailRateLimitExceeded if the email has hit the hourly verification cap.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
-
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             _enforce_email_verification_quota(session, email)
 
@@ -1034,12 +1133,11 @@ def verify_email_subscription(engine, token: str) -> bool:
     If the verification record has a pending_watch_release_id, the watch
     is automatically added after successful verification.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
     
     pending_release_id = None
     subscription_id = None
 
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             # Find verification record
             verification = session.scalar(
@@ -1089,9 +1187,7 @@ def unsubscribe_email(engine, token: str) -> Optional[str]:
     the rotation grace window). Returns the email address that was removed,
     or None if the token was invalid.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
-
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             subscription = session.scalar(_unsubscribe_token_select(token))
 
@@ -1116,10 +1212,9 @@ def record_bounce(engine, email: str) -> Optional[Dict[str, Any]]:
     Returns a dict with the outcome, or None if no matching subscriber.
     Only counts one bounce per calendar day to prevent rapid deactivation.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
     now = datetime.utcnow()
 
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             sub = session.scalar(
                 select(EmailSubscriptionModel)
@@ -1149,9 +1244,7 @@ def record_bounce(engine, email: str) -> Optional[Dict[str, Any]]:
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def get_active_subscriptions(engine) -> List[EmailSubscriptionModel]:
     """Get all active and verified email subscriptions"""
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         subscriptions = session.scalars(
             select(EmailSubscriptionModel)
             .where(EmailSubscriptionModel.is_active == True)
@@ -1168,8 +1261,7 @@ def get_unsent_active_subscriptions(engine, time_frame: int, cadence: Optional[s
 
     If *cadence* is provided, only subscriptions matching that cadence are returned.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         query = (
             select(EmailSubscriptionModel)
             .where(EmailSubscriptionModel.is_active == True)
@@ -1214,8 +1306,7 @@ def get_digest_eligible_subscriptions(engine) -> List[EmailSubscriptionModel]:
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def get_release_item_by_id(engine, release_item_id: str) -> Optional[ReleaseItemModel]:
     """Return a ReleaseItemModel by primary key, or None if not found."""
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         item = session.get(ReleaseItemModel, release_item_id)
         if item:
             session.expunge(item)
@@ -1225,8 +1316,7 @@ def get_release_item_by_id(engine, release_item_id: str) -> Optional[ReleaseItem
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def add_feature_watch(engine, subscription_id: str, release_item_id: str) -> bool:
     """Add a feature watch. Returns True if created, False if already exists."""
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             existing = session.scalar(
                 select(FeatureWatchModel).where(
@@ -1254,8 +1344,7 @@ def add_feature_watch(engine, subscription_id: str, release_item_id: str) -> boo
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def remove_feature_watch(engine, subscription_id: str, release_item_id: str) -> bool:
     """Remove a feature watch. Returns True if deleted, False if not found."""
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             result = session.execute(
                 delete(FeatureWatchModel).where(
@@ -1269,8 +1358,7 @@ def remove_feature_watch(engine, subscription_id: str, release_item_id: str) -> 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def get_watched_changes(engine, subscription_id: str) -> List[Dict[str, Any]]:
     """Return watched releases whose row_hash differs from last_notified_hash."""
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         rows = session.execute(
             select(FeatureWatchModel, ReleaseItemModel)
             .join(ReleaseItemModel, FeatureWatchModel.release_item_id == ReleaseItemModel.release_item_id)
@@ -1304,8 +1392,7 @@ def update_watch_hashes(engine, hash_updates: List[Tuple[str, str]]):
     """Update last_notified_hash for a list of (watch_id, new_hash) tuples."""
     if not hash_updates:
         return
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             # Bulk update — single roundtrip instead of one session.get() per id.
             session.bulk_update_mappings(
@@ -1322,8 +1409,7 @@ def get_subscription_by_unsubscribe_token(engine, token: str) -> Optional[EmailS
     Accepts either the current unsubscribe_token or the previous one (within
     the rotation grace window).
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         sub = session.scalar(_unsubscribe_token_select(token))
         if sub:
             session.expunge(sub)
@@ -1333,8 +1419,7 @@ def get_subscription_by_unsubscribe_token(engine, token: str) -> Optional[EmailS
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def get_verified_subscription_by_email(engine, email: str) -> Optional[EmailSubscriptionModel]:
     """Look up a verified, active subscription by email address."""
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         sub = session.scalar(
             select(EmailSubscriptionModel)
             .where(EmailSubscriptionModel.email == email.strip().lower())
@@ -1354,9 +1439,8 @@ def update_subscription_preferences(engine, token: str, preferences: Dict[str, A
     Accepts either the current unsubscribe_token or the previous one (within
     the rotation grace window). Returns True if subscription found and updated.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
     allowed_keys = {'email_cadence', 'product_filter', 'release_type_filter', 'release_status_filter'}
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         with session.begin():
             sub = session.scalar(_unsubscribe_token_select(token))
             if not sub:
@@ -1370,8 +1454,7 @@ def update_subscription_preferences(engine, token: str, preferences: Dict[str, A
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def get_feature_watches_for_subscription(engine, subscription_id: str) -> List[Dict[str, Any]]:
     """Return all feature watches for a subscription with release details."""
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         rows = session.execute(
             select(FeatureWatchModel, ReleaseItemModel.feature_name, ReleaseItemModel.product_name)
             .join(ReleaseItemModel, FeatureWatchModel.release_item_id == ReleaseItemModel.release_item_id)
@@ -1399,8 +1482,7 @@ def get_subscriptions_with_changed_watches(engine) -> List[Tuple[EmailSubscripti
 
     Uses a single joined query to avoid N+1 DB round-trips.
     """
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         rows = session.execute(
             select(EmailSubscriptionModel, FeatureWatchModel, ReleaseItemModel)
             .join(FeatureWatchModel, EmailSubscriptionModel.id == FeatureWatchModel.subscription_id)
@@ -1476,6 +1558,49 @@ def fetch_history_rows(engine, release_item_id: str):
             pass
         conn.close()
 
+
+def _build_vector_search_where(
+    *,
+    product_name: Optional[str] = None,
+    release_type: Optional[str] = None,
+    release_status: Optional[str] = None,
+    modified_within_days: Optional[int] = None,
+    include_inactive: bool = False,
+    now: Optional[datetime] = None,
+) -> Tuple[str, List[Any]]:
+    """Build the shared WHERE-clause + positional params for the vector
+    search and its companion COUNT query.
+
+    Both call sites previously assembled identical filter logic by hand,
+    which made adding/removing a filter a two-edit chore and risked drift.
+    Centralizing here keeps the two queries provably consistent.
+
+    The ``now`` argument is injected for tests so ``modified_within_days``
+    cutoff comparisons aren't tied to wall-clock time.
+    """
+    conditions = ["release_vector IS NOT NULL"]
+    params: List[Any] = []
+
+    if not include_inactive:
+        conditions.append("active = 1")
+    if product_name is not None:
+        conditions.append("product_name = ?")
+        params.append(product_name)
+    if release_type is not None:
+        conditions.append("release_type = ?")
+        params.append(release_type)
+    if release_status is not None:
+        conditions.append("release_status = ?")
+        params.append(release_status)
+    if modified_within_days is not None:
+        anchor = now or datetime.utcnow()
+        cutoff = (anchor - timedelta(days=modified_within_days)).date()
+        conditions.append("last_modified >= ?")
+        params.append(cutoff)
+
+    return " AND ".join(conditions), params
+
+
 @retry_on_transient_errors(max_attempts=5, initial_delay=1.0, backoff=2.0, max_delay=60.0)
 def vector_search_releases(
     engine,
@@ -1491,26 +1616,13 @@ def vector_search_releases(
     """Search releases ordered by cosine similarity to query_vector."""
     vector_json = json.dumps(query_vector)
 
-    conditions = ["release_vector IS NOT NULL"]
-    filter_params: List[Any] = []
-
-    if not include_inactive:
-        conditions.append("active = 1")
-    if product_name is not None:
-        conditions.append("product_name = ?")
-        filter_params.append(product_name)
-    if release_type is not None:
-        conditions.append("release_type = ?")
-        filter_params.append(release_type)
-    if release_status is not None:
-        conditions.append("release_status = ?")
-        filter_params.append(release_status)
-    if modified_within_days is not None:
-        cutoff = (datetime.utcnow() - timedelta(days=modified_within_days)).date()
-        conditions.append("last_modified >= ?")
-        filter_params.append(cutoff)
-
-    where_sql = " AND ".join(conditions)
+    where_sql, filter_params = _build_vector_search_where(
+        product_name=product_name,
+        release_type=release_type,
+        release_status=release_status,
+        modified_within_days=modified_within_days,
+        include_inactive=include_inactive,
+    )
 
     sql = f"""
     SELECT release_item_id, feature_name, release_date, release_type,
@@ -1550,26 +1662,13 @@ def count_vector_search_releases(
     include_inactive: bool = False,
 ) -> int:
     """Count vectorized releases matching the given filters."""
-    conditions = ["release_vector IS NOT NULL"]
-    params: List[Any] = []
-
-    if not include_inactive:
-        conditions.append("active = 1")
-    if product_name is not None:
-        conditions.append("product_name = ?")
-        params.append(product_name)
-    if release_type is not None:
-        conditions.append("release_type = ?")
-        params.append(release_type)
-    if release_status is not None:
-        conditions.append("release_status = ?")
-        params.append(release_status)
-    if modified_within_days is not None:
-        cutoff = (datetime.utcnow() - timedelta(days=modified_within_days)).date()
-        conditions.append("last_modified >= ?")
-        params.append(cutoff)
-
-    where_sql = " AND ".join(conditions)
+    where_sql, params = _build_vector_search_where(
+        product_name=product_name,
+        release_type=release_type,
+        release_status=release_status,
+        modified_within_days=modified_within_days,
+        include_inactive=include_inactive,
+    )
     sql = f"SELECT COUNT(*) FROM release_items WHERE {where_sql}"
 
     conn = engine.raw_connection()

--- a/server.py
+++ b/server.py
@@ -12,7 +12,6 @@ from flask_limiter import Limiter
 from html import escape
 from email.utils import format_datetime
 import hashlib
-from sqlalchemy.orm import sessionmaker
 
 import logging
 # Import the `configure_azure_monitor()` function from the
@@ -45,6 +44,7 @@ from db.db_sqlserver import (
     create_watch_verification, get_release_item_by_id,
     EmailRateLimitExceeded,
     rotate_unsubscribe_token,
+    session_scope,
 )
 from lib.embeddings import get_embedding, is_available as embeddings_available
 
@@ -967,8 +967,7 @@ def api_releases():
     # Single item path
     if release_item_id:
         engine = get_engine()
-        SessionLocal = sessionmaker(bind=engine, future=True)
-        with SessionLocal() as session:
+        with session_scope(engine) as session:
             row = session.get(ReleaseItemModel, release_item_id)
             if not row:
                 return jsonify({"error": "release_item_id not found"}), 404
@@ -1082,8 +1081,7 @@ def api_version():
     that can be appended to other API calls as a cache-buster.
     """
     engine = get_engine()
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         row = session.query(ReleaseItemModel.release_item_id).order_by(
             ReleaseItemModel.last_modified.desc()
         ).first()
@@ -1229,10 +1227,8 @@ def verify_email_page():
     watch_feature_name = None
     try:
         engine = get_engine()
-        from sqlalchemy.orm import sessionmaker
         from sqlalchemy import select as sa_select
-        SessionLocal = sessionmaker(bind=engine, future=True)
-        with SessionLocal() as session:
+        with session_scope(engine) as session:
             verification = session.scalar(
                 sa_select(EmailVerificationModel).where(EmailVerificationModel.token == token)
             )
@@ -1463,8 +1459,7 @@ def about_page():
 def release_detail(release_item_id):
     """Server-rendered release detail page for SEO."""
     engine = get_engine()
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         row = session.get(ReleaseItemModel, release_item_id)
         if not row:
             return render_template('release.html', release=None, history=None), 404
@@ -1477,8 +1472,7 @@ def release_detail(release_item_id):
 def watch_feature_page(release_item_id):
     """Page to subscribe to watch alerts for a specific release item."""
     engine = get_engine()
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         release = session.get(ReleaseItemModel, release_item_id)
         if not release:
             return render_template('watch.html', release=None, error="Release not found"), 404
@@ -1704,8 +1698,7 @@ def sitemap_xml():
     job, so a one-hour TTL aligns with the freshness window.
     """
     engine = get_engine()
-    SessionLocal = sessionmaker(bind=engine, future=True)
-    with SessionLocal() as session:
+    with session_scope(engine) as session:
         releases = session.query(
             ReleaseItemModel.release_item_id,
             ReleaseItemModel.last_modified,

--- a/tests/test_release_fields.py
+++ b/tests/test_release_fields.py
@@ -1,0 +1,175 @@
+"""Tests for ``_RELEASE_FIELDS``, ``_normalize_for_hash``, and
+``_map_to_model_kwargs`` (M8 — single source of truth for release fields).
+
+The two helpers used to maintain parallel lists of (PascalCase API name,
+snake_case model attr) pairs. A renaming refactor that touched only one
+of them would silently invalidate every row hash, causing every roadmap
+item to re-vectorize on the next run. These tests pin the contract.
+"""
+
+from datetime import date
+
+from db.db_sqlserver import (
+    _RELEASE_FIELDS,
+    _compute_row_hash,
+    _map_to_model_kwargs,
+    _normalize_for_hash,
+)
+
+
+# A fully-populated input using PascalCase keys (mirrors what the Fabric
+# roadmap API returns).
+_API_ITEM = {
+    "ReleaseItemID": "abcd-1234",
+    "FeatureName": "Feature X",
+    "FeatureDescription": "Feature X description",
+    "ReleaseDate": "2026-04-01",
+    "ReleaseType": "GA",
+    "ReleaseStatus": "Launched",
+    "ReleaseSemester": "2026 H1",
+    "ReleaseTypeValue": "1",
+    "ReleaseStatusValue": "2",
+    "VSOItem": "VSO-9999",
+    "ProductID": 12345,
+    "ProductName": "Fabric",
+    "isPublishExternally": "true",
+}
+
+
+# Same content using snake_case keys (mirrors the ReleaseItem dataclass).
+_MODEL_ITEM = {
+    "release_item_id": "abcd-1234",
+    "feature_name": "Feature X",
+    "feature_description": "Feature X description",
+    "release_date": date(2026, 4, 1),
+    "release_type": "GA",
+    "release_status": "Launched",
+    "release_semester": "2026 H1",
+    "release_type_value": 1,
+    "release_status_value": 2,
+    "vso_item": "VSO-9999",
+    "product_id": "12345",
+    "product_name": "Fabric",
+    "is_publish_externally": True,
+}
+
+
+class TestReleaseFieldsRegistry:
+    def test_release_item_id_is_excluded(self):
+        """``release_item_id`` identifies the row but is not part of its
+        content. It must never enter the hash, otherwise every primary-key
+        change would force re-vectorization."""
+        api_names = {f.api_name for f in _RELEASE_FIELDS}
+        model_attrs = {f.model_attr for f in _RELEASE_FIELDS}
+        assert "ReleaseItemID" not in api_names
+        assert "release_item_id" not in model_attrs
+
+    def test_all_expected_content_fields_present(self):
+        """If a developer adds/removes a content field on
+        ``ReleaseItemModel`` they MUST update ``_RELEASE_FIELDS`` too —
+        this test will fail until they do."""
+        expected_model_attrs = {
+            "feature_name",
+            "feature_description",
+            "release_date",
+            "release_type",
+            "release_status",
+            "release_semester",
+            "release_type_value",
+            "release_status_value",
+            "vso_item",
+            "product_id",
+            "product_name",
+            "is_publish_externally",
+        }
+        assert {f.model_attr for f in _RELEASE_FIELDS} == expected_model_attrs
+
+
+class TestNormalizeForHash:
+    def test_pascalcase_input(self):
+        out = _normalize_for_hash(_API_ITEM)
+        assert out == {
+            "FeatureName": "Feature X",
+            "FeatureDescription": "Feature X description",
+            "ReleaseDate": "2026-04-01",
+            "ReleaseType": "GA",
+            "ReleaseStatus": "Launched",
+            "ReleaseSemester": "2026 H1",
+            "ReleaseTypeValue": 1,
+            "ReleaseStatusValue": 2,
+            "VSOItem": "VSO-9999",
+            "ProductID": "12345",
+            "ProductName": "Fabric",
+            "isPublishExternally": True,
+        }
+
+    def test_snakecase_input_produces_same_hash(self):
+        """Both helpers fall through to ``_get(item, api_name, model_attr)``
+        — the underlying ``_get`` accepts whichever key is present. So
+        both representations must hash identically."""
+        h1 = _compute_row_hash(_normalize_for_hash(_API_ITEM))
+        h2 = _compute_row_hash(_normalize_for_hash(_MODEL_ITEM))
+        assert h1 == h2
+
+    def test_none_freetext_normalizes_to_empty_string(self):
+        """``feature_name`` and ``feature_description`` use ``v or ''`` in
+        the hash so a NULL→"" UI cleanup doesn't churn the hash."""
+        item = {**_API_ITEM, "FeatureName": None, "FeatureDescription": None}
+        out = _normalize_for_hash(item)
+        assert out["FeatureName"] == ""
+        assert out["FeatureDescription"] == ""
+
+    def test_missing_release_date_yields_none(self):
+        item = {**_API_ITEM, "ReleaseDate": None}
+        assert _normalize_for_hash(item)["ReleaseDate"] is None
+
+    def test_release_item_id_does_not_affect_hash(self):
+        """The whole point of M8: changing the row's PK must not change
+        its content hash."""
+        item_a = {**_API_ITEM, "ReleaseItemID": "id-aaa"}
+        item_b = {**_API_ITEM, "ReleaseItemID": "id-bbb"}
+        assert _compute_row_hash(_normalize_for_hash(item_a)) == _compute_row_hash(_normalize_for_hash(item_b))
+
+
+class TestMapToModelKwargs:
+    def test_pascalcase_input(self):
+        out = _map_to_model_kwargs(_API_ITEM)
+        assert out["release_item_id"] == "abcd-1234"
+        assert out["feature_name"] == "Feature X"
+        assert out["feature_description"] == "Feature X description"
+        assert out["release_date"] == date(2026, 4, 1)
+        assert out["release_type"] == "GA"
+        assert out["release_type_value"] == 1
+        assert out["release_status_value"] == 2
+        assert out["product_id"] == "12345"
+        assert out["product_name"] == "Fabric"
+        assert out["is_publish_externally"] is True
+
+    def test_missing_release_item_id_generates_uuid(self):
+        item = {k: v for k, v in _API_ITEM.items() if k != "ReleaseItemID"}
+        out = _map_to_model_kwargs(item)
+        # Should be a valid UUID string (length 36, contains hyphens).
+        assert isinstance(out["release_item_id"], str)
+        assert len(out["release_item_id"]) == 36
+        assert out["release_item_id"].count("-") == 4
+
+    def test_none_freetext_preserved_as_none(self):
+        """Unlike the hash, the model preserves real ``None`` for free-text
+        fields so it round-trips correctly."""
+        item = {**_API_ITEM, "FeatureName": None, "FeatureDescription": None}
+        out = _map_to_model_kwargs(item)
+        assert out["feature_name"] is None
+        assert out["feature_description"] is None
+
+    def test_invalid_int_yields_none(self):
+        item = {**_API_ITEM, "ReleaseTypeValue": "not-a-number"}
+        assert _map_to_model_kwargs(item)["release_type_value"] is None
+
+    def test_no_overlapping_keys_with_hash_payload(self):
+        """A fresh sanity check: every key the hash emits is PascalCase,
+        every key the model emits is snake_case, so there's zero overlap.
+        If this ever fails, someone introduced ambiguity that could let
+        the two helpers drift."""
+        hash_keys = set(_normalize_for_hash(_API_ITEM).keys())
+        model_keys = set(_map_to_model_kwargs(_API_ITEM).keys())
+        assert hash_keys.isdisjoint(model_keys)

--- a/tests/test_session_scope.py
+++ b/tests/test_session_scope.py
@@ -1,0 +1,123 @@
+"""Tests for ``db.db_sqlserver.session_scope``.
+
+Uses an in-memory SQLite engine so we exercise the real SQLAlchemy
+machinery (Session lifecycle, transaction commit/rollback, attribute
+detachment) without needing SQL Server / pyodbc.
+"""
+
+import pytest
+import sqlalchemy
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.exc import InvalidRequestError
+from sqlalchemy.orm import declarative_base
+
+from db.db_sqlserver import session_scope
+
+
+Base = declarative_base()
+
+
+class _Toy(Base):
+    __tablename__ = "toy"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50), nullable=False)
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(eng)
+    return eng
+
+
+def test_session_scope_yields_session_bound_to_engine(engine):
+    with session_scope(engine) as session:
+        assert isinstance(session, sqlalchemy.orm.Session)
+        assert session.bind is engine
+
+
+def test_session_scope_closes_session_on_exit(engine):
+    captured = {}
+    with session_scope(engine) as session:
+        captured["session"] = session
+        assert session.is_active
+
+    # ``Session.is_active`` stays True after close in modern SQLAlchemy
+    # (close ends the transaction but the Session itself can be reused).
+    # The reliable post-close signal is that ``in_transaction()`` is False
+    # and that no autobegin transaction is currently open.
+    assert captured["session"].in_transaction() is False
+
+
+def test_nested_session_begin_commits_on_success(engine):
+    """The nested ``with session.begin():`` pattern (used in 12 sites
+    today) must still commit when the inner block exits cleanly."""
+    with session_scope(engine) as session:
+        with session.begin():
+            session.add(_Toy(id=1, name="alpha"))
+
+    # Open a fresh session to verify the row was actually committed.
+    with session_scope(engine) as session:
+        toy = session.get(_Toy, 1)
+        assert toy is not None
+        assert toy.name == "alpha"
+
+
+def test_nested_session_begin_rolls_back_on_exception(engine):
+    """An exception inside ``with session.begin():`` must roll back so
+    callers don't end up with half-applied state."""
+    with pytest.raises(RuntimeError, match="boom"):
+        with session_scope(engine) as session:
+            with session.begin():
+                session.add(_Toy(id=2, name="bravo"))
+                raise RuntimeError("boom")
+
+    with session_scope(engine) as session:
+        assert session.get(_Toy, 2) is None
+
+
+def test_session_scope_does_not_implicitly_commit(engine):
+    """``session_scope`` is lifecycle-only — it must NOT commit on its
+    own. Otherwise every read-only call site would trigger a needless
+    transaction flush, and the 12 ``with session.begin():`` blocks would
+    have their semantics altered."""
+    with session_scope(engine) as session:
+        # Add a row WITHOUT wrapping in session.begin(). Since session_scope
+        # doesn't commit, the row must not persist.
+        session.add(_Toy(id=3, name="charlie"))
+
+    with session_scope(engine) as session:
+        assert session.get(_Toy, 3) is None
+
+
+def test_session_scope_each_call_returns_new_session(engine):
+    """Two consecutive calls must return different Session instances so
+    state from one block can't leak into the next."""
+    with session_scope(engine) as s1:
+        s1_id = id(s1)
+    with session_scope(engine) as s2:
+        s2_id = id(s2)
+    assert s1_id != s2_id
+
+
+def test_expunge_all_detaches_orm_rows(engine):
+    """M13 convention check: rows that were expunge_all'd while the
+    session was open are flagged as detached after the session closes,
+    which is exactly what callers need to safely use them outside the
+    ``with`` block.
+    """
+    with session_scope(engine) as session:
+        with session.begin():
+            session.add(_Toy(id=99, name="zulu"))
+
+    with session_scope(engine) as session:
+        rows = session.query(_Toy).all()
+        session.expunge_all()
+
+    # Outside the ``with`` block the session is closed. A detached row
+    # can still have its already-loaded attributes read (so callers don't
+    # blow up touching ``row.name``), and ``inspect`` confirms the state.
+    assert len(rows) >= 1
+    state = sqlalchemy.inspect(rows[0])
+    assert state.detached is True
+    assert rows[0].name == "zulu"  # loaded attribute is safe to read

--- a/tests/test_vector_search_where.py
+++ b/tests/test_vector_search_where.py
@@ -1,0 +1,94 @@
+"""Tests for ``_build_vector_search_where`` (M2 — shared WHERE builder).
+
+The two vector-search functions used to assemble identical filter logic
+by hand. Centralizing here keeps them provably consistent.
+"""
+
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from db.db_sqlserver import _build_vector_search_where
+
+
+def test_default_filters_only_active_with_vector():
+    where_sql, params = _build_vector_search_where()
+    assert where_sql == "release_vector IS NOT NULL AND active = 1"
+    assert params == []
+
+
+def test_include_inactive_drops_active_filter():
+    where_sql, params = _build_vector_search_where(include_inactive=True)
+    assert where_sql == "release_vector IS NOT NULL"
+    assert params == []
+
+
+def test_product_name_filter():
+    where_sql, params = _build_vector_search_where(product_name="Fabric")
+    assert where_sql == "release_vector IS NOT NULL AND active = 1 AND product_name = ?"
+    assert params == ["Fabric"]
+
+
+def test_release_type_filter():
+    where_sql, params = _build_vector_search_where(release_type="GA")
+    assert where_sql == "release_vector IS NOT NULL AND active = 1 AND release_type = ?"
+    assert params == ["GA"]
+
+
+def test_release_status_filter():
+    where_sql, params = _build_vector_search_where(release_status="Launched")
+    assert where_sql == "release_vector IS NOT NULL AND active = 1 AND release_status = ?"
+    assert params == ["Launched"]
+
+
+def test_modified_within_days_uses_now_for_cutoff():
+    """The ``now`` injection point exists exactly so this test isn't
+    flaky around midnight UTC."""
+    fixed_now = datetime(2026, 4, 22, 12, 0, 0)
+    where_sql, params = _build_vector_search_where(
+        modified_within_days=7,
+        now=fixed_now,
+    )
+    assert where_sql == "release_vector IS NOT NULL AND active = 1 AND last_modified >= ?"
+    assert params == [date(2026, 4, 15)]
+
+
+def test_all_filters_combined_in_documented_order():
+    """Param order must match the SQL WHERE order — otherwise pyodbc
+    will bind the wrong value to the wrong placeholder."""
+    fixed_now = datetime(2026, 4, 22, 12, 0, 0)
+    where_sql, params = _build_vector_search_where(
+        product_name="Fabric",
+        release_type="GA",
+        release_status="Launched",
+        modified_within_days=30,
+        include_inactive=True,
+        now=fixed_now,
+    )
+    assert where_sql == (
+        "release_vector IS NOT NULL"
+        " AND product_name = ?"
+        " AND release_type = ?"
+        " AND release_status = ?"
+        " AND last_modified >= ?"
+    )
+    assert params == ["Fabric", "GA", "Launched", date(2026, 3, 23)]
+
+
+def test_count_and_search_use_identical_where():
+    """Regression guard for M2: both call sites must call
+    ``_build_vector_search_where`` with the same kwargs and get the
+    same WHERE clause. We emulate by calling once and confirming the
+    output is a plain function of the kwargs."""
+    fixed_now = datetime(2026, 4, 22, 12, 0, 0)
+    common = dict(
+        product_name="Fabric",
+        release_type="GA",
+        release_status="Launched",
+        modified_within_days=14,
+        include_inactive=False,
+        now=fixed_now,
+    )
+    a = _build_vector_search_where(**common)
+    b = _build_vector_search_where(**common)
+    assert a == b

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -29,7 +29,7 @@ from db.db_sqlserver import (
     make_engine, get_unsent_active_subscriptions, EmailSubscriptionModel,
     EmailVerificationModel, EmailContentCacheModel,
     get_digest_eligible_subscriptions, get_subscriptions_with_changed_watches,
-    update_watch_hashes,
+    update_watch_hashes, session_scope,
 )
 
 try:
@@ -168,18 +168,16 @@ class WeeklyEmailSender:
         on the same date reuse the cached content so every subscriber
         with identical settings gets the exact same email.
         """
-        from sqlalchemy.orm import sessionmaker
         from sqlalchemy import select as sa_select
 
         cache_key = self._build_cache_key(subscription)
         cache_date = datetime.utcnow().strftime('%Y-%m-%d')
 
         engine = self._engine or make_engine()
-        SessionLocal = sessionmaker(bind=engine, future=True)
 
         # Try DB cache
         try:
-            with SessionLocal() as session:
+            with session_scope(engine) as session:
                 row = session.scalar(
                     sa_select(EmailContentCacheModel)
                     .where(EmailContentCacheModel.cache_date == cache_date)
@@ -222,7 +220,7 @@ class WeeklyEmailSender:
         try:
             content = json.dumps({'changes': items, 'ai_summary': ai_summary},
                                  separators=(',', ':'))
-            with SessionLocal() as session:
+            with session_scope(engine) as session:
                 with session.begin():
                     session.add(EmailContentCacheModel(
                         cache_date=cache_date,
@@ -507,9 +505,7 @@ class WeeklyEmailSender:
         """Update the last_email_sent timestamp for a subscription"""
         try:
             engine = self._engine or make_engine()
-            from sqlalchemy.orm import sessionmaker
-            SessionLocal = sessionmaker(bind=engine, future=True)
-            with SessionLocal() as session:
+            with session_scope(engine) as session:
                 subscription = session.get(EmailSubscriptionModel, subscription_id)
                 if subscription:
                     subscription.last_email_sent = datetime.utcnow()
@@ -871,13 +867,11 @@ body,table,td,p,a {{ font-family:'Segoe UI',system-ui,-apple-system,BlinkMacSyst
         - Old email content cache entries (older than 2 days)
         Returns dict of counts removed.
         """
-        from sqlalchemy.orm import sessionmaker
         from sqlalchemy import delete, or_, and_
-        SessionLocal = sessionmaker(bind=engine, future=True)
         now = datetime.utcnow()
         threshold = now - timedelta(hours=24)
         counts = {"expired_or_used_verifications": 0, "stale_unverified": 0, "old_cache_entries": 0}
-        with SessionLocal() as session:
+        with session_scope(engine) as session:
             # Expired or used verifications
             expired_stmt = delete(EmailVerificationModel).where(
                 or_(EmailVerificationModel.expires_at < now, EmailVerificationModel.is_used == True)


### PR DESCRIPTION
## Summary

Bundles 4 medium-priority code-quality findings from the recent review — all in `db/db_sqlserver.py` and its callers. Pure refactor; **zero behavior change is the goal**, verified by 26 new tests plus the existing 97-test suite (124 passing).

| ID  | Finding                                              | Fix                                                                                                                |
| --- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| M1  | `SessionLocal = sessionmaker(...)` duplicated 32×    | New `session_scope(engine)` context manager; replaced all 32 sites across `db_sqlserver.py`, `server.py`, `weekly_email_job.py` |
| M2  | Vector-search WHERE clause duplicated across 2 funcs | Extracted `_build_vector_search_where(*, ..., now=None)`; both `vector_search_releases` and `count_vector_search_releases` call it |
| M8  | Release field list maintained twice (hash vs model)  | Single `_RELEASE_FIELDS: List[_ReleaseFieldSpec]` registry drives both `_normalize_for_hash` and `_map_to_model_kwargs` |
| M13 | `get_recently_modified_releases` returned attached rows after session close | Added `session.expunge_all()` after `.all()` inside the `with` block; module docstring documents the convention |

## Design notes (rubber-duck-driven)

- **No memoization on `session_scope`.** `sessionmaker` is cheap (small hash-table-shaped object). Memoizing by `id(engine)` risks reuse bugs across test engines; memoizing by reference risks holding test engines alive. Building a fresh sessionmaker per call is the simpler, safer choice.
- **`session_scope` is lifecycle-only — it does NOT auto-commit.** This is critical: 12 sites use the nested `with session_scope(engine) as session: with session.begin(): ...` pattern. If `session_scope` committed on exit, those nested transactions would change semantics. A test pins this contract (`test_session_scope_does_not_implicitly_commit`).
- **`_ReleaseFieldSpec` keeps separate `hash_transform` and `model_transform`.** Three fields legitimately diverge:
  - `FeatureName` / `FeatureDescription`: hash uses `v or ""` (so an existing `NULL → ""` cleanup doesn't churn the hash); model preserves real `None`.
  - `ReleaseDate`: hash uses ISO string (stable JSON output); model uses real `date` object.
- **`release_item_id` is intentionally NOT in `_RELEASE_FIELDS`.** It identifies the row, not its content. If it leaked into the hash, every PK regeneration would force re-vectorization. `_map_to_model_kwargs` adds it explicitly after iterating the spec.
- **`expunge_all()` MUST be after `.all()`.** First plan was to call it before — that would have been a no-op since rows aren't loaded yet. Caught by the rubber-duck pass.
- **`now` parameter on `_build_vector_search_where`.** Lets cutoff-date tests use `freezegun`-style frozen times and avoid flake around midnight UTC.

## Tests added (26)

- `tests/test_session_scope.py` (7) — yields bound session, closes on exit, nested `begin()` commits on success / rolls back on exception, no implicit commit, fresh session per call, `expunge_all()` produces detached rows (verified via `sqlalchemy.inspect`)
- `tests/test_release_fields.py` (12) — registry excludes `release_item_id`, all expected model attrs present, PascalCase + snake_case input produce identical hash, `None` freetext → `""` in hash but `None` in model, PK doesn't affect hash, missing `ReleaseItemID` generates UUID, hash/model key sets are disjoint
- `tests/test_vector_search_where.py` (8) — default filters, `include_inactive`, each filter individually, all combined in documented param order with frozen `now` for date-cutoff determinism (catches positional-`?` binding regressions)

## Verification

- `pytest`: 124 passed (97 existing + 27 new — including the bonus detached-state assertion)
- `python -c 'import server'` and `python -c 'import weekly_email_job'` both clean with `CURRENT_ENVIRONMENT=development`
- Hash backward compatibility verified field-by-field; old and new `_normalize_for_hash` produce byte-identical output for the same input (no churn risk on existing rows)
- Code-review sub-agent ran on the staged diff and reported no issues

## Out of scope (deferred)

- M3, M4 → next PR (server route cleanup)
- M9 → following PR (Alembic)
- M5, M6, M14, M15 → tracked issues
