### PR TITLE
Server route cleanup: dedup ACS monitor + promote inline ORM to helpers

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -1314,6 +1314,112 @@ def get_release_item_by_id(engine, release_item_id: str) -> Optional[ReleaseItem
 
 
 @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_latest_release_version(engine) -> str:
+    """Return the ``release_item_id`` of the most-recently-modified release.
+
+    Used as a cache-buster value by ``/api/version``. ``last_modified`` is a
+    Date column so many rows share the same latest day; we add
+    ``release_item_id desc`` as a stable secondary sort so the returned
+    value doesn't flap between equally-recent rows. Returns ``""`` when no
+    releases exist.
+    """
+    with session_scope(engine) as session:
+        row = session.execute(
+            select(ReleaseItemModel.release_item_id)
+            .order_by(
+                ReleaseItemModel.last_modified.desc(),
+                ReleaseItemModel.release_item_id.desc(),
+            )
+            .limit(1)
+        ).first()
+        return row[0] if row else ""
+
+
+@dataclass(frozen=True)
+class SitemapRelease:
+    """Lightweight detached row used by the XML sitemap renderer."""
+
+    release_item_id: str
+    last_modified: Optional[date]
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_active_releases_for_sitemap(engine) -> List[SitemapRelease]:
+    """Return id + last_modified for every active release.
+
+    The sitemap route needs only these two columns and must be safe to use
+    after the session closes — returning frozen dataclass instances avoids
+    detached-ORM-row pitfalls.
+    """
+    with session_scope(engine) as session:
+        rows = session.execute(
+            select(
+                ReleaseItemModel.release_item_id,
+                ReleaseItemModel.last_modified,
+            ).where(ReleaseItemModel.active == True)  # noqa: E712 (SQLAlchemy boolean comparison)
+        ).all()
+        return [
+            SitemapRelease(release_item_id=r[0], last_modified=r[1])
+            for r in rows
+        ]
+
+
+@dataclass(frozen=True)
+class VerifyEmailContext:
+    """Display-only context for the verify-email GET page."""
+
+    cadence: str
+    watch_feature_name: Optional[str]
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
+def get_verify_email_context(engine, token: str) -> Optional[VerifyEmailContext]:
+    """Return display context for the verify-email GET page, or ``None``.
+
+    The lookup is intentionally permissive: we filter only by *token* and
+    return context whenever the verification row exists. This preserves the
+    existing GET-page behavior — even a stale or already-used token still
+    renders cadence and the watched-feature label so the user sees
+    consistent context if they bounce back to the page.
+
+    - ``cadence`` defaults to ``'weekly'`` if no subscription exists yet
+      (e.g. brand-new signup verifying for the first time).
+    - ``watch_feature_name`` is populated only when the verification has a
+      ``pending_watch_release_id`` and that release still exists.
+    """
+    with session_scope(engine) as session:
+        verification = session.scalar(
+            select(EmailVerificationModel).where(
+                EmailVerificationModel.token == token
+            )
+        )
+        if verification is None:
+            return None
+
+        cadence = 'weekly'
+        watch_feature_name = None
+
+        sub = session.scalar(
+            select(EmailSubscriptionModel).where(
+                EmailSubscriptionModel.email == verification.email
+            )
+        )
+        if sub:
+            cadence = sub.email_cadence or 'weekly'
+
+        if verification.pending_watch_release_id:
+            release = session.get(
+                ReleaseItemModel, verification.pending_watch_release_id
+            )
+            if release:
+                watch_feature_name = release.feature_name
+
+        return VerifyEmailContext(
+            cadence=cadence, watch_feature_name=watch_feature_name
+        )
+
+
+@retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
 def add_feature_watch(engine, subscription_id: str, release_item_id: str) -> bool:
     """Add a feature watch. Returns True if created, False if already exists."""
     with session_scope(engine) as session:

--- a/server.py
+++ b/server.py
@@ -4,7 +4,6 @@ import urllib.parse
 import threading
 import logging
 from datetime import datetime, date, time, timezone
-from types import SimpleNamespace
 from typing import Optional, List
 
 from flask import Flask, request, Response, jsonify, render_template, redirect, send_from_directory, url_for
@@ -31,7 +30,7 @@ except ImportError:
 
 from db.db_sqlserver import (
     make_engine, get_recently_modified_releases, init_db, ReleaseItemModel, get_distinct_values, fetch_history_rows,
-    EmailSubscriptionModel, EmailVerificationModel, create_email_subscription, 
+    create_email_subscription,
     verify_email_subscription, unsubscribe_email, fetch_history_rows, count_recently_modified_releases,
     vector_search_releases, count_vector_search_releases,
     record_bounce,
@@ -42,9 +41,10 @@ from db.db_sqlserver import (
     get_verified_subscription_by_email,
     add_feature_watch, remove_feature_watch, get_feature_watches_for_subscription,
     create_watch_verification, get_release_item_by_id,
+    get_latest_release_version, get_active_releases_for_sitemap,
+    get_verify_email_context,
     EmailRateLimitExceeded,
     rotate_unsubscribe_token,
-    session_scope,
 )
 from lib.embeddings import get_embedding, is_available as embeddings_available
 
@@ -248,6 +248,40 @@ def get_email_client():
     return EMAIL_CLIENT
 
 
+def _monitor_acs_send(poller, *, recipient: str, kind: str) -> None:
+    """Run on a background thread; logs the outcome of an async ACS send.
+
+    *kind* is the human-readable email type (``'verification'``,
+    ``'preferences link'``, ``'goodbye'``) used in the log messages. Status
+    extraction tries the most common ACS shapes in order:
+
+    1. ``result.status`` — ``SendStatusResult``-style attribute (most common
+       in current SDK versions). Checked first so successful sends aren't
+       logged as ``status=None``.
+    2. ``result['status']`` — dict-shaped result.
+    3. ``result.get('status')`` — mapping-like with a ``get`` method.
+
+    All three branches converge on the same success/warning/error logging
+    so the three call sites can no longer drift.
+    """
+    try:
+        result = poller.result()
+        status = getattr(result, 'status', None)
+        if status is None and isinstance(result, dict):
+            status = result.get('status')
+        if status is None:
+            getter = getattr(result, 'get', None)
+            if callable(getter):
+                status = getter('status')
+        kind_label = kind.capitalize()
+        if status == 'Succeeded':
+            otelLogger.info(f"{kind_label} email sent to {recipient}")
+        else:
+            otelLogger.warning(f"{kind_label} email status for {recipient}: {status}")
+    except Exception as monitor_exc:
+        otelLogger.error(f"Error monitoring {kind} email send to {recipient}: {monitor_exc}")
+
+
 def send_verification_email(email: str, verification_token: str,
                             cadence: str = 'weekly', watch_feature_name: Optional[str] = None) -> bool:
     """Send verification email using Azure Communication Services"""
@@ -395,16 +429,7 @@ Fabric GPS
                 return False
 
             def _monitor_send(poller_obj, target_email):
-                try:
-                    # Wait up to 3 minutes; adjust if needed
-                    result = poller_obj.result()
-                    status = result.get('status') if isinstance(result, dict) else getattr(result, 'get', lambda *_: None)('status')
-                    if status == 'Succeeded':
-                        otelLogger.info(f"Verification email sent to {target_email}")
-                    else:
-                        otelLogger.warning(f"Verification email status for {target_email}: {status}")
-                except Exception as monitor_exc:
-                    otelLogger.error(f"Error monitoring verification email send to {target_email}: {monitor_exc}")
+                _monitor_acs_send(poller_obj, recipient=target_email, kind='verification')
 
             threading.Thread(target=_monitor_send, args=(poller, email), daemon=True).start()
             return True
@@ -526,15 +551,7 @@ Fabric GPS
             return False
 
         def _monitor_send(poller_obj, target_email):
-            try:
-                result = poller_obj.result()
-                status = result.get('status') if isinstance(result, dict) else None
-                if status == 'Succeeded':
-                    otelLogger.info(f"Preferences link email sent to {target_email}")
-                else:
-                    otelLogger.warning(f"Preferences link email status for {target_email}: {status}")
-            except Exception as monitor_exc:
-                otelLogger.error(f"Error monitoring preferences link email to {target_email}: {monitor_exc}")
+            _monitor_acs_send(poller_obj, recipient=target_email, kind='preferences link')
 
         threading.Thread(target=_monitor_send, args=(poller, email), daemon=True).start()
         return True
@@ -630,15 +647,7 @@ Fabric GPS
         poller = email_client.begin_send(message)
 
         def _monitor_send(poller_obj, target_email):
-            try:
-                result = poller_obj.result()
-                status = result.get('status') if isinstance(result, dict) else getattr(result, 'get', lambda *_: None)('status')
-                if status == 'Succeeded':
-                    otelLogger.info(f"Goodbye email sent to {target_email}")
-                else:
-                    otelLogger.warning(f"Goodbye email status for {target_email}: {status}")
-            except Exception as monitor_exc:
-                otelLogger.error(f"Error monitoring goodbye email send to {target_email}: {monitor_exc}")
+            _monitor_acs_send(poller_obj, recipient=target_email, kind='goodbye')
 
         threading.Thread(target=_monitor_send, args=(poller, email), daemon=True).start()
         return True
@@ -967,13 +976,12 @@ def api_releases():
     # Single item path
     if release_item_id:
         engine = get_engine()
-        with session_scope(engine) as session:
-            row = session.get(ReleaseItemModel, release_item_id)
-            if not row:
-                return jsonify({"error": "release_item_id not found"}), 404
-            data = _row_to_dict(row)
-            json_item = json.dumps(data, sort_keys=True, separators=(",", ":"))
-            return _make_cached_response(json_item, last_modified=row.last_modified)
+        row = get_release_item_by_id(engine, release_item_id)
+        if not row:
+            return jsonify({"error": "release_item_id not found"}), 404
+        data = _row_to_dict(row)
+        json_item = json.dumps(data, sort_keys=True, separators=(",", ":"))
+        return _make_cached_response(json_item, last_modified=row.last_modified)
 
     # Generate embedding for vector search when q is provided
     query_embedding = None
@@ -1081,11 +1089,7 @@ def api_version():
     that can be appended to other API calls as a cache-buster.
     """
     engine = get_engine()
-    with session_scope(engine) as session:
-        row = session.query(ReleaseItemModel.release_item_id).order_by(
-            ReleaseItemModel.last_modified.desc()
-        ).first()
-        version = row.release_item_id if row else ""
+    version = get_latest_release_version(engine)
     resp = jsonify({"version": version})
     resp.headers['Cache-Control'] = 'no-store'
     return resp
@@ -1227,21 +1231,10 @@ def verify_email_page():
     watch_feature_name = None
     try:
         engine = get_engine()
-        from sqlalchemy import select as sa_select
-        with session_scope(engine) as session:
-            verification = session.scalar(
-                sa_select(EmailVerificationModel).where(EmailVerificationModel.token == token)
-            )
-            if verification:
-                sub = session.scalar(
-                    sa_select(EmailSubscriptionModel).where(EmailSubscriptionModel.email == verification.email)
-                )
-                if sub:
-                    cadence = sub.email_cadence or 'weekly'
-                if verification.pending_watch_release_id:
-                    release = session.get(ReleaseItemModel, verification.pending_watch_release_id)
-                    if release:
-                        watch_feature_name = release.feature_name
+        ctx = get_verify_email_context(engine, token)
+        if ctx is not None:
+            cadence = ctx.cadence
+            watch_feature_name = ctx.watch_feature_name
     except Exception as e:
         # Surface, but don't fail the page — the GET is purely informational
         # (cadence + watch-feature label). The user can still POST the form
@@ -1459,12 +1452,11 @@ def about_page():
 def release_detail(release_item_id):
     """Server-rendered release detail page for SEO."""
     engine = get_engine()
-    with session_scope(engine) as session:
-        row = session.get(ReleaseItemModel, release_item_id)
-        if not row:
-            return render_template('release.html', release=None, history=None), 404
-        history = fetch_history_rows(engine, release_item_id)
-        return render_template('release.html', release=row, history=history)
+    row = get_release_item_by_id(engine, release_item_id)
+    if not row:
+        return render_template('release.html', release=None, history=None), 404
+    history = fetch_history_rows(engine, release_item_id)
+    return render_template('release.html', release=row, history=history)
 
 
 @app.route("/watch/<release_item_id>", methods=["GET", "POST"])
@@ -1472,12 +1464,11 @@ def release_detail(release_item_id):
 def watch_feature_page(release_item_id):
     """Page to subscribe to watch alerts for a specific release item."""
     engine = get_engine()
-    with session_scope(engine) as session:
-        release = session.get(ReleaseItemModel, release_item_id)
-        if not release:
-            return render_template('watch.html', release=None, error="Release not found"), 404
-        feature_name = release.feature_name
-        product_name = release.product_name
+    release = get_release_item_by_id(engine, release_item_id)
+    if not release:
+        return render_template('watch.html', release=None, error="Release not found"), 404
+    feature_name = release.feature_name
+    product_name = release.product_name
 
     if request.method == 'POST':
         email = (request.form.get('email') or '').strip().lower()
@@ -1698,22 +1689,8 @@ def sitemap_xml():
     job, so a one-hour TTL aligns with the freshness window.
     """
     engine = get_engine()
-    with session_scope(engine) as session:
-        releases = session.query(
-            ReleaseItemModel.release_item_id,
-            ReleaseItemModel.last_modified,
-        ).filter(ReleaseItemModel.active == True).all()
-        # Materialize plain rows + grab last-modified before the session
-        # closes so the cache helper can set a data-derived Last-Modified
-        # header (and so we don't pass detached ORM rows around).
-        release_rows = [
-            SimpleNamespace(
-                release_item_id=r.release_item_id,
-                last_modified=r.last_modified,
-            )
-            for r in releases
-        ]
-        last_modified = _max_last_modified(release_rows)
+    release_rows = get_active_releases_for_sitemap(engine)
+    last_modified = _max_last_modified(release_rows)
 
     body = _render_sitemap_xml(EMAIL_BASE_URL, release_rows)
     return _make_cached_response(

--- a/tests/test_db_route_helpers.py
+++ b/tests/test_db_route_helpers.py
@@ -1,0 +1,205 @@
+"""Tests for the new route-supporting helpers in ``db.db_sqlserver``.
+
+Covers:
+* ``get_latest_release_version`` — used by ``/api/version`` as a cache-buster
+* ``get_active_releases_for_sitemap`` — used by ``/sitemap.xml``
+* ``get_verify_email_context`` — used by the GET ``/verify-email`` page
+
+We use an in-memory SQLite engine and re-create the real model tables so
+we exercise the actual ORM mappings end-to-end without needing SQL Server
+or pyodbc. The vector / SQL-Server-specific bits live only in raw SQL
+strings, so ``Base.metadata.create_all`` works against SQLite.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.db_sqlserver import (
+    Base,
+    EmailSubscriptionModel,
+    EmailVerificationModel,
+    ReleaseItemModel,
+    SitemapRelease,
+    VerifyEmailContext,
+    get_active_releases_for_sitemap,
+    get_latest_release_version,
+    get_verify_email_context,
+)
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(eng)
+    return eng
+
+
+def _add_release(engine, *, release_item_id, last_modified, active=True,
+                 feature_name="Feature", row_hash="x" * 64):
+    from sqlalchemy.orm import Session
+    with Session(engine) as s:
+        s.add(ReleaseItemModel(
+            release_item_id=release_item_id,
+            feature_name=feature_name,
+            row_hash=row_hash,
+            last_modified=last_modified,
+            active=active,
+        ))
+        s.commit()
+
+
+# ---------------------------------------------------------------------------
+# get_latest_release_version
+# ---------------------------------------------------------------------------
+
+def test_latest_version_empty_table_returns_empty_string(engine):
+    assert get_latest_release_version(engine) == ""
+
+
+def test_latest_version_returns_most_recent(engine):
+    _add_release(engine, release_item_id="aaa", last_modified=date(2025, 1, 1))
+    _add_release(engine, release_item_id="bbb", last_modified=date(2025, 6, 15))
+    _add_release(engine, release_item_id="ccc", last_modified=date(2025, 3, 1))
+    assert get_latest_release_version(engine) == "bbb"
+
+
+def test_latest_version_breaks_ties_by_release_item_id_desc(engine):
+    """When several rows share the same ``last_modified`` date the helper
+    must return a deterministic value (sorted by id desc) rather than
+    flapping between equally-recent rows on each call."""
+    same_day = date(2025, 4, 22)
+    _add_release(engine, release_item_id="aaa", last_modified=same_day)
+    _add_release(engine, release_item_id="zzz", last_modified=same_day)
+    _add_release(engine, release_item_id="mmm", last_modified=same_day)
+    # Repeat a few times to assert determinism.
+    results = {get_latest_release_version(engine) for _ in range(5)}
+    assert results == {"zzz"}
+
+
+# ---------------------------------------------------------------------------
+# get_active_releases_for_sitemap
+# ---------------------------------------------------------------------------
+
+def test_sitemap_helper_filters_inactive(engine):
+    _add_release(engine, release_item_id="active-1", last_modified=date(2025, 1, 1), active=True)
+    _add_release(engine, release_item_id="active-2", last_modified=date(2025, 2, 1), active=True)
+    _add_release(engine, release_item_id="archived", last_modified=date(2024, 1, 1), active=False)
+
+    rows = get_active_releases_for_sitemap(engine)
+    ids = sorted(r.release_item_id for r in rows)
+    assert ids == ["active-1", "active-2"]
+
+
+def test_sitemap_helper_returns_frozen_dataclass(engine):
+    _add_release(engine, release_item_id="r1", last_modified=date(2025, 5, 5))
+    rows = get_active_releases_for_sitemap(engine)
+    assert len(rows) == 1
+    row = rows[0]
+    assert isinstance(row, SitemapRelease)
+    assert row.release_item_id == "r1"
+    assert row.last_modified == date(2025, 5, 5)
+    # Frozen dataclass — must reject mutation.
+    with pytest.raises(Exception):
+        row.release_item_id = "r2"  # type: ignore[misc]
+
+
+def test_sitemap_helper_empty_returns_empty_list(engine):
+    assert get_active_releases_for_sitemap(engine) == []
+
+
+# ---------------------------------------------------------------------------
+# get_verify_email_context
+# ---------------------------------------------------------------------------
+
+def _add_verification(engine, *, token, email, pending_watch_release_id=None,
+                      is_used=False):
+    from sqlalchemy.orm import Session
+    with Session(engine) as s:
+        s.add(EmailVerificationModel(
+            email=email,
+            token=token,
+            action_type="subscribe",
+            expires_at=datetime.utcnow() + timedelta(days=1),
+            is_used=is_used,
+            pending_watch_release_id=pending_watch_release_id,
+        ))
+        s.commit()
+
+
+def _add_subscription(engine, *, email, cadence="weekly", is_verified=True):
+    from sqlalchemy.orm import Session
+    with Session(engine) as s:
+        s.add(EmailSubscriptionModel(
+            email=email,
+            is_verified=is_verified,
+            email_cadence=cadence,
+            unsubscribe_token="unsub-" + email,
+        ))
+        s.commit()
+
+
+def test_verify_context_unknown_token_returns_none(engine):
+    assert get_verify_email_context(engine, "no-such-token") is None
+
+
+def test_verify_context_no_subscription_yet_defaults_to_weekly(engine):
+    """A brand-new signup whose subscription row hasn't been created
+    should still render display context with the default weekly cadence."""
+    _add_verification(engine, token="tok-new", email="new@example.com")
+    ctx = get_verify_email_context(engine, "tok-new")
+    assert ctx == VerifyEmailContext(cadence="weekly", watch_feature_name=None)
+
+
+def test_verify_context_uses_subscription_cadence(engine):
+    _add_verification(engine, token="tok-daily", email="daily@example.com")
+    _add_subscription(engine, email="daily@example.com", cadence="daily")
+    ctx = get_verify_email_context(engine, "tok-daily")
+    assert ctx is not None
+    assert ctx.cadence == "daily"
+
+
+def test_verify_context_resolves_watch_feature_name(engine):
+    _add_release(engine, release_item_id="rel-watch", last_modified=date(2025, 1, 1),
+                 feature_name="Direct Lake on OneLake")
+    _add_verification(engine, token="tok-watch", email="watch@example.com",
+                      pending_watch_release_id="rel-watch")
+    ctx = get_verify_email_context(engine, "tok-watch")
+    assert ctx is not None
+    assert ctx.watch_feature_name == "Direct Lake on OneLake"
+
+
+def test_verify_context_missing_release_leaves_watch_name_none(engine):
+    """If pending_watch_release_id points to a release that no longer
+    exists (deleted / archived hard-delete), context should still be
+    returned — cadence is independent of the watch lookup."""
+    _add_verification(engine, token="tok-stale", email="stale@example.com",
+                      pending_watch_release_id="missing-release-id")
+    _add_subscription(engine, email="stale@example.com", cadence="weekly")
+    ctx = get_verify_email_context(engine, "tok-stale")
+    assert ctx is not None
+    assert ctx.watch_feature_name is None
+    assert ctx.cadence == "weekly"
+
+
+def test_verify_context_used_token_still_returns_display_context(engine):
+    """The GET page is purely informational — even an already-used token
+    should render context if the row still exists. The route uses the
+    POST handler (not this helper) to enforce token validity."""
+    _add_verification(engine, token="tok-used", email="used@example.com",
+                      is_used=True)
+    _add_subscription(engine, email="used@example.com", cadence="weekly")
+    ctx = get_verify_email_context(engine, "tok-used")
+    assert ctx is not None
+    assert ctx.cadence == "weekly"
+
+
+def test_verify_context_returns_frozen_dataclass(engine):
+    _add_verification(engine, token="tok-frozen", email="frozen@example.com")
+    ctx = get_verify_email_context(engine, "tok-frozen")
+    assert ctx is not None
+    with pytest.raises(Exception):
+        ctx.cadence = "daily"  # type: ignore[misc]

--- a/tests/test_monitor_acs_send.py
+++ b/tests/test_monitor_acs_send.py
@@ -1,0 +1,105 @@
+"""Tests for ``server._monitor_acs_send``.
+
+The helper runs on a background thread and converts an ACS poller result
+into a structured log line. Real ACS results in current SDK versions are
+``SendStatusResult``-style objects with a ``.status`` attribute, but
+older / mocked results may be dicts or other mapping-shaped objects.
+
+We verify all three shapes plus the failure-mode log paths so the three
+call sites can no longer drift.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import server
+
+
+@pytest.fixture
+def captured_logs(monkeypatch):
+    """Capture otelLogger.info / .warning / .error calls."""
+    calls = {"info": [], "warning": [], "error": []}
+
+    def make_recorder(level):
+        def _rec(msg, *args, **kwargs):
+            # Mirror %-formatting if args are passed (otelLogger usage is
+            # mostly f-string-based, but be safe).
+            calls[level].append(msg % args if args else msg)
+        return _rec
+
+    monkeypatch.setattr(server.otelLogger, "info", make_recorder("info"))
+    monkeypatch.setattr(server.otelLogger, "warning", make_recorder("warning"))
+    monkeypatch.setattr(server.otelLogger, "error", make_recorder("error"))
+    return calls
+
+
+def _make_poller(result):
+    poller = MagicMock()
+    poller.result.return_value = result
+    return poller
+
+
+def test_succeeded_status_attribute_logs_info(captured_logs):
+    """Real ACS SendStatusResult-style: ``.status`` attribute."""
+    poller = _make_poller(SimpleNamespace(status="Succeeded"))
+    server._monitor_acs_send(poller, recipient="alice@example.com", kind="verification")
+    assert captured_logs["info"] == ["Verification email sent to alice@example.com"]
+    assert captured_logs["warning"] == []
+    assert captured_logs["error"] == []
+
+
+def test_succeeded_status_dict_logs_info(captured_logs):
+    """Dict-shaped result, ``status`` key."""
+    poller = _make_poller({"status": "Succeeded"})
+    server._monitor_acs_send(poller, recipient="bob@example.com", kind="goodbye")
+    assert captured_logs["info"] == ["Goodbye email sent to bob@example.com"]
+
+
+def test_succeeded_status_via_get_method(captured_logs):
+    """Mapping-like object with ``.get`` but no ``.status`` and not a dict."""
+    class FakeMapping:
+        def get(self, key):
+            return "Succeeded" if key == "status" else None
+
+    poller = _make_poller(FakeMapping())
+    server._monitor_acs_send(poller, recipient="carol@example.com", kind="preferences link")
+    assert captured_logs["info"] == ["Preferences link email sent to carol@example.com"]
+
+
+def test_non_success_status_logs_warning(captured_logs):
+    poller = _make_poller(SimpleNamespace(status="Failed"))
+    server._monitor_acs_send(poller, recipient="dave@example.com", kind="verification")
+    assert captured_logs["warning"] == ["Verification email status for dave@example.com: Failed"]
+    assert captured_logs["info"] == []
+
+
+def test_unknown_shape_logs_warning_with_none(captured_logs):
+    """Result has neither ``.status`` nor dict shape nor ``.get`` — log warning."""
+    class Opaque:
+        pass
+
+    poller = _make_poller(Opaque())
+    server._monitor_acs_send(poller, recipient="eve@example.com", kind="goodbye")
+    assert captured_logs["warning"] == ["Goodbye email status for eve@example.com: None"]
+
+
+def test_poller_exception_logs_error(captured_logs):
+    poller = MagicMock()
+    poller.result.side_effect = RuntimeError("boom")
+    server._monitor_acs_send(poller, recipient="frank@example.com", kind="verification")
+    assert len(captured_logs["error"]) == 1
+    assert "frank@example.com" in captured_logs["error"][0]
+    assert "boom" in captured_logs["error"][0]
+    assert captured_logs["info"] == []
+    assert captured_logs["warning"] == []
+
+
+def test_kind_label_is_capitalized_in_log(captured_logs):
+    """``kind`` only affects log text; verify the capitalize() formatting."""
+    poller = _make_poller(SimpleNamespace(status="Succeeded"))
+    server._monitor_acs_send(poller, recipient="x@example.com", kind="preferences link")
+    assert captured_logs["info"] == ["Preferences link email sent to x@example.com"]


### PR DESCRIPTION
## Summary

Bundles 2 medium-priority findings from the recent code-quality review — pure refactor, plus one latent-bug fix in the email-send monitor that was uncovered during the rubber-duck pass.

| ID  | Finding                                                          | Fix                                                                                                                                  |
| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
| M3  | `_monitor_send` closure duplicated across 3 send functions       | Extracted `_monitor_acs_send(poller, *, recipient, kind)` in `server.py`. All three sites now delegate to it.                         |
| M4  | 6 inline ORM queries in route handlers bypassed the db helper layer | 3 sites now use existing `get_release_item_by_id`; 3 new retry-decorated helpers in `db_sqlserver.py` cover the remaining patterns. |

## Latent bug fixed in M3

The original three `_monitor_send` closures all assumed `poller.result()` returned a dict and read status via `result.get('status')`. Real Azure Communication Services `poller.result()` returns a `SendStatusResult`-shaped object with a `.status` **attribute**, not a dict. Result: every successful production send was being logged as `status=None` warning instead of `status=Succeeded` info.

The new helper tries `result.status` first, then `result['status']` (dict), then `result.get('status')` (mapping-like). All three shapes are covered by tests.

## New helpers in `db/db_sqlserver.py`

| Helper                              | Replaces                                                | Notes                                                                                                                       |
| ----------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| `get_latest_release_version`        | inline query in `/api/version`                          | Stable secondary sort `(last_modified desc, release_item_id desc)` so the cache-buster value doesn't flap between same-day rows |
| `get_active_releases_for_sitemap`   | inline query + `SimpleNamespace` materialization in `/sitemap.xml` | Returns frozen `SitemapRelease` dataclass — no detached-ORM-row risk                                                        |
| `get_verify_email_context`          | inline triple-query in `/verify-email` GET             | Token-only lookup (no `is_used` / `expires_at` filter) preserves the page's purely-informational behavior                   |

All four new helpers (`get_release_item_by_id` already existed) use the **short retry profile** (`max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0`) so a transient SQL outage can't push past Front Door's request timeout.

## Design notes (rubber-duck-driven)

- **`.status` attribute checked first.** Initial plan checked dict first; rubber-duck flagged that real ACS `SendStatusResult` doesn't satisfy `isinstance(result, dict)` so the original code path never extracted a real status.
- **Stable tiebreaker on `get_latest_release_version`.** `last_modified` is a Date column, so many rows share the same value. Without `release_item_id desc` as secondary sort, the cache-buster value would flap arbitrarily between equally-recent rows.
- **`get_verify_email_context` keeps loose token-only lookup.** Original GET semantics rendered display context (cadence label, watch-feature name) even for stale or already-used tokens. The helper preserves that — the POST handler enforces token validity, not the GET helper.
- **Frozen dataclasses for return rows.** `SitemapRelease` and `VerifyEmailContext` are `@dataclass(frozen=True)` so callers can't accidentally mutate them and so they're safe to pass between threads/contexts.

## Cleanups in `server.py`

- Removed imports: `session_scope`, `EmailVerificationModel`, `EmailSubscriptionModel`, `SimpleNamespace`
- Removed inline `from sqlalchemy import select as sa_select` in the verify-email route
- Three `_monitor_send` closures collapsed to one-line delegates

## Tests added (20)

- `tests/test_monitor_acs_send.py` (7) — `.status` attribute path, dict path, `.get()` mapping path, non-success warning, opaque object → warning, poller exception → error, kind-label capitalization
- `tests/test_db_route_helpers.py` (13) — empty/populated/tied `get_latest_release_version`, sitemap filters/dataclass shape/empty, verify-context unknown token / no subscription / cadence override / watch-feature resolution / missing release / used token / frozen-dataclass

## Verification

- `pytest`: 144 passed (124 existing + 20 new)
- `python -c 'import server'` clean with `CURRENT_ENVIRONMENT=development`
- Code-review sub-agent ran on the staged diff and confirmed the M3 fix is a strict superset of the old behavior (no regressions, fixes a real bug)

## Out of scope (deferred)

- M9 → next PR (Alembic populate `add_email_subscription_tables`)
- M5, M6, M14, M15 → tracked issues
