### PR TITLE
Batch DB commits in vectorize/match pipeline (closes #76)

### DIFF
--- a/lib/batch_commit.py
+++ b/lib/batch_commit.py
@@ -1,0 +1,184 @@
+"""Batch-commit helper for the raw-pyodbc pipeline scripts.
+
+The vectorize and match pipeline scripts used to open a fresh DB connection
+and ``COMMIT`` per item, paying a TLS + auth round-trip on every row. With
+100+ items per run that adds significant Azure SQL latency and pool churn.
+
+This helper centralizes the "hold one connection, commit every N successful
+items" pattern (issue #76 / M14) so both scripts share the same logic and
+the logic itself is easy to unit-test without a live SQL Server.
+
+Trade-off (documented for callers):
+    A larger batch reduces round-trips but means a single transient connection
+    failure mid-batch loses the *uncommitted* items in that window — they
+    revert to ``WHERE x_vector IS NULL`` and get re-processed on the next
+    pipeline run. The pipeline is idempotent, so this only delays work, it
+    doesn't lose it. ``BATCH_COMMIT_SIZE`` defaults to 25 to keep that window
+    small while still cutting commits ~25x.
+
+Per-item retry (PR #67) is preserved: callers wrap each statement in a
+``try/except`` that drops + reconnects on transient errors, then re-runs
+the statement against the fresh connection. The ``BatchCommitter`` exposes
+``replace_connection()`` for that path so the counter logic stays consistent
+across reconnects.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_COMMIT_SIZE = 25
+BATCH_COMMIT_SIZE_ENV = "BATCH_COMMIT_SIZE"
+
+
+def get_batch_commit_size(
+    default: int = DEFAULT_BATCH_COMMIT_SIZE,
+    env_var: str = BATCH_COMMIT_SIZE_ENV,
+) -> int:
+    """Resolve the configured batch commit size.
+
+    Reads ``BATCH_COMMIT_SIZE`` from the environment. Falls back to *default*
+    when the env var is unset, empty, non-numeric, or non-positive.
+    """
+    raw = os.getenv(env_var)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %d", env_var, raw, default
+        )
+        return default
+    if value <= 0:
+        logger.warning(
+            "Non-positive %s=%d; using default %d", env_var, value, default
+        )
+        return default
+    return value
+
+
+class BatchCommitter:
+    """Commit a pyodbc connection every ``batch_size`` successful items.
+
+    Usage::
+
+        with BatchCommitter(conn, batch_size=25) as bc:
+            for item in items:
+                try:
+                    cursor.execute("UPDATE ...", params)
+                except Exception:
+                    log_and_continue(item)  # failed item is NOT marked done
+                    continue
+                bc.mark_success()
+            # __exit__ flushes any remaining pending items on success,
+            # or rolls back the in-flight batch on exception.
+
+    Notes:
+        * ``mark_success()`` is called *after* the per-item statement returns
+          without error. A raised exception means the item never landed in
+          the transaction, so the counter is not advanced.
+        * ``flush()`` is idempotent and a no-op when nothing is pending.
+        * If a caller reconnects mid-batch (transient-error recovery), it
+          should call ``replace_connection(new_conn)`` so subsequent commits
+          target the live connection. The pending counter is reset because
+          the in-flight transaction died with the old connection.
+    """
+
+    def __init__(
+        self,
+        conn,
+        batch_size: int = DEFAULT_BATCH_COMMIT_SIZE,
+        *,
+        on_commit: Optional[Callable[[int], None]] = None,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        self._conn = conn
+        self._batch_size = int(batch_size)
+        self._on_commit = on_commit
+        self.pending = 0
+        self.committed = 0
+
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
+    @property
+    def connection(self):
+        return self._conn
+
+    def mark_success(self) -> None:
+        """Record one successful item; commit when the batch fills up."""
+        self.pending += 1
+        if self.pending >= self._batch_size:
+            self.flush()
+
+    def flush(self) -> None:
+        """Commit any pending items. No-op when ``pending == 0``."""
+        if self.pending == 0:
+            return
+        if self._conn is None:
+            logger.warning(
+                "BatchCommitter.flush() called with no connection; "
+                "dropping %d pending item(s).",
+                self.pending,
+            )
+            self.pending = 0
+            return
+        n = self.pending
+        self._conn.commit()
+        self.committed += n
+        self.pending = 0
+        if self._on_commit is not None:
+            try:
+                self._on_commit(n)
+            except Exception:  # noqa: BLE001 — callback errors must not poison the batch
+                logger.exception("BatchCommitter on_commit callback raised; ignoring.")
+
+    def rollback_pending(self) -> int:
+        """Roll back uncommitted work. Returns the number of items dropped."""
+        dropped = self.pending
+        if dropped == 0:
+            return 0
+        if self._conn is not None:
+            try:
+                self._conn.rollback()
+            except Exception:  # noqa: BLE001 — best-effort, connection may already be dead
+                logger.exception("BatchCommitter rollback raised; ignoring.")
+        self.pending = 0
+        return dropped
+
+    def replace_connection(self, new_conn) -> int:
+        """Swap to a fresh connection (e.g. after a transient-error reconnect).
+
+        The pending counter is reset to 0 because the prior in-flight
+        transaction died with the old connection. Returns the number of
+        items that were lost from the in-flight batch (0 when the swap
+        happened on a clean batch boundary).
+        """
+        lost = self.pending
+        self._conn = new_conn
+        self.pending = 0
+        if lost:
+            logger.warning(
+                "BatchCommitter: connection replaced with %d uncommitted "
+                "item(s) in flight; those rows will be re-processed on the "
+                "next pipeline run.",
+                lost,
+            )
+        return lost
+
+    def __enter__(self) -> "BatchCommitter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if exc_type is None:
+            self.flush()
+        else:
+            self.rollback_pending()
+        return False

--- a/match_releases_to_blogs.py
+++ b/match_releases_to_blogs.py
@@ -12,6 +12,7 @@ import pyodbc
 from openai import AzureOpenAI
 import json
 
+from lib.batch_commit import BatchCommitter, get_batch_commit_size
 from lib.db_retry import retry_on_transient_errors, is_transient_sql_azure_error
 from lib.telemetry import init_telemetry
 
@@ -223,7 +224,6 @@ class ReleaseBlogMatcher:
             """
 
             self.cursor.execute(update_sql, (embedding.model_dump_json(), release_item_id))
-            self.commit()
             return True
 
         return self._run_with_reconnect(body)
@@ -283,7 +283,6 @@ class ReleaseBlogMatcher:
             """
 
             self.cursor.execute(update_sql, (blog_title, blog_url, distance, release_item_id))
-            self.commit()
             return True
 
         return self._run_with_reconnect(body)
@@ -295,71 +294,111 @@ class ReleaseBlogMatcher:
         try:
             # Get releases without vectors
             releases = self.get_releases_without_articles()
-            
+
             if not releases:
                 logger.info("No releases found that need vectorization")
                 return
-            
-            logger.info(f"Starting vectorization and matching of {len(releases)} releases")
-            
+
+            commit_size = get_batch_commit_size()
+            logger.info(
+                f"Starting vectorization and matching of {len(releases)} "
+                f"releases (commit every {commit_size})"
+            )
+
             success_count = 0
             failure_count = 0
             matched_count = 0
-            
-            for i, release in enumerate(releases, 1):
-                try:
-                    logger.info(f"Processing release {i}/{len(releases)}: {release['feature_name']}")
-                    if release['release_vector'] == '':
-                        # Create combined text
-                        text = self.create_text_for_embedding(release)
-                        
-                        if not text.strip():
-                            logger.warning(f"Skipping release {release['release_item_id']} - no content to vectorize")
-                            failure_count += 1
-                            continue
-                        
-                        # Generate embedding
-                        embedding = self.generate_embedding(text)
-                        
-                        if not embedding:
-                            logger.error(f"Failed to generate embedding for release {release['release_item_id']}")
-                            failure_count += 1
-                            continue
-                        
-                        # Update release vector in database
-                        if not self.update_release_vector(release['release_item_id'], embedding):
-                            logger.error(f"Failed to update vector for release {release['release_item_id']}")
-                            failure_count += 1
-                            continue
-                        
-                        success_count += 1
-                        logger.info(f"✓ Successfully vectorized release {release['release_item_id']}")
-                    else: 
-                        logger.info(f"✓ {release['release_item_id']} already vectorized!")
-                    
-                    # Find most related blog article
-                    blog_match = self.find_most_related_blog(release['release_item_id'])
-                    
-                    if blog_match:
-                        blog_title, blog_url, distance = blog_match
-                        if distance <= self.MAXIMUM_VECTOR_DISTANCE:
-                            logger.info(f"  → Found related blog: '{blog_title}' (distance: {distance:.4f})")
-                            
-                            # Update release with blog info
-                            if self.update_release_blog_info(release['release_item_id'], blog_title, blog_url, distance):
-                                matched_count += 1
-                                logger.info(f"  ✓ Updated release with blog info")
-                            else:
-                                logger.error(f"  ✗ Failed to update release with blog info")
+
+            self._ensure_connection()
+            with BatchCommitter(self.conn, batch_size=commit_size) as committer:
+                for i, release in enumerate(releases, 1):
+                    try:
+                        logger.info(f"Processing release {i}/{len(releases)}: {release['feature_name']}")
+
+                        item_dirty = False  # tracks whether we staged any UPDATE for this release
+
+                        if release['release_vector'] == '':
+                            # Create combined text
+                            text = self.create_text_for_embedding(release)
+
+                            if not text.strip():
+                                logger.warning(f"Skipping release {release['release_item_id']} - no content to vectorize")
+                                failure_count += 1
+                                continue
+
+                            # Generate embedding (API errors must NOT poison the SQL conn)
+                            embedding = self.generate_embedding(text)
+
+                            if not embedding:
+                                logger.error(f"Failed to generate embedding for release {release['release_item_id']}")
+                                failure_count += 1
+                                continue
+
+                            # Stage the UPDATE; commit is deferred to the BatchCommitter.
+                            try:
+                                self.update_release_vector(release['release_item_id'], embedding)
+                            except Exception as e:
+                                if committer.connection is not self.conn:
+                                    committer.replace_connection(self.conn)
+                                logger.error(f"Failed to update vector for release {release['release_item_id']}: {e}")
+                                failure_count += 1
+                                continue
+
+                            if committer.connection is not self.conn:
+                                committer.replace_connection(self.conn)
+
+                            item_dirty = True
+                            success_count += 1
+                            logger.info(f"✓ Successfully vectorized release {release['release_item_id']}")
                         else:
-                            logger.warning(f"  ⚠ Related article too disimilar")
-                    else:
-                        logger.warning(f"  ⚠ No related blog article found")
-                
-                except Exception as e:
-                    logger.error(f"Error processing release {release['release_item_id']}: {e}")
-                    failure_count += 1
-            
+                            logger.info(f"✓ {release['release_item_id']} already vectorized!")
+
+                        # Find most related blog article
+                        try:
+                            blog_match = self.find_most_related_blog(release['release_item_id'])
+                        except Exception as e:
+                            if committer.connection is not self.conn:
+                                committer.replace_connection(self.conn)
+                            logger.error(f"  ✗ Lookup failed for release {release['release_item_id']}: {e}")
+                            if item_dirty:
+                                committer.mark_success()
+                            failure_count += 1
+                            continue
+
+                        if committer.connection is not self.conn:
+                            committer.replace_connection(self.conn)
+
+                        if blog_match:
+                            blog_title, blog_url, distance = blog_match
+                            if distance <= self.MAXIMUM_VECTOR_DISTANCE:
+                                logger.info(f"  → Found related blog: '{blog_title}' (distance: {distance:.4f})")
+
+                                try:
+                                    self.update_release_blog_info(
+                                        release['release_item_id'], blog_title, blog_url, distance
+                                    )
+                                    item_dirty = True
+                                    matched_count += 1
+                                    logger.info(f"  ✓ Updated release with blog info")
+                                except Exception as e:
+                                    if committer.connection is not self.conn:
+                                        committer.replace_connection(self.conn)
+                                    logger.error(f"  ✗ Failed to update release with blog info: {e}")
+                            else:
+                                logger.warning(f"  ⚠ Related article too disimilar")
+                        else:
+                            logger.warning(f"  ⚠ No related blog article found")
+
+                        if committer.connection is not self.conn:
+                            committer.replace_connection(self.conn)
+
+                        if item_dirty:
+                            committer.mark_success()
+
+                    except Exception as e:
+                        logger.error(f"Error processing release {release['release_item_id']}: {e}")
+                        failure_count += 1
+
             # Final summary
             logger.info("=" * 60)
             logger.info(f"Vectorization and matching complete!")
@@ -368,7 +407,7 @@ class ReleaseBlogMatcher:
             logger.info(f"Failed: {failure_count}")
             logger.info(f"Total processed: {len(releases)}")
             logger.info("=" * 60)
-        
+
         except Exception as e:
             logger.error(f"Fatal error during vectorization and matching: {e}")
             raise
@@ -415,34 +454,59 @@ class ReleaseBlogMatcher:
                 logger.info("No matched releases to rerank")
                 return
 
-            logger.info(f"Reranking blog matches for {len(releases)} releases")
+            commit_size = get_batch_commit_size()
+            logger.info(
+                f"Reranking blog matches for {len(releases)} releases "
+                f"(commit every {commit_size})"
+            )
             improved_count = 0
 
-            for i, release in enumerate(releases, 1):
-                try:
-                    blog_match = self.find_most_related_blog(release['release_item_id'])
-                    if not blog_match:
-                        continue
+            self._ensure_connection()
+            with BatchCommitter(self.conn, batch_size=commit_size) as committer:
+                for i, release in enumerate(releases, 1):
+                    try:
+                        try:
+                            blog_match = self.find_most_related_blog(release['release_item_id'])
+                        except Exception:
+                            if committer.connection is not self.conn:
+                                committer.replace_connection(self.conn)
+                            raise
 
-                    new_title, new_url, new_distance = blog_match
-                    if new_distance > self.MAXIMUM_VECTOR_DISTANCE:
-                        continue
+                        if committer.connection is not self.conn:
+                            committer.replace_connection(self.conn)
 
-                    old_distance = release.get('vector_distance')
-                    # Update if the new match is closer or the matched blog changed
-                    if old_distance is None or new_distance < old_distance:
-                        logger.info(
-                            f"  ↑ [{i}/{len(releases)}] {release['feature_name']}: "
-                            f"distance {old_distance} → {new_distance:.4f} "
-                            f"('{new_title}')"
-                        )
-                        self.update_release_blog_info(
-                            release['release_item_id'], new_title, new_url, new_distance
-                        )
-                        improved_count += 1
+                        if not blog_match:
+                            continue
 
-                except Exception as e:
-                    logger.error(f"Error reranking release {release['release_item_id']}: {e}")
+                        new_title, new_url, new_distance = blog_match
+                        if new_distance > self.MAXIMUM_VECTOR_DISTANCE:
+                            continue
+
+                        old_distance = release.get('vector_distance')
+                        # Update if the new match is closer or the matched blog changed
+                        if old_distance is None or new_distance < old_distance:
+                            logger.info(
+                                f"  ↑ [{i}/{len(releases)}] {release['feature_name']}: "
+                                f"distance {old_distance} → {new_distance:.4f} "
+                                f"('{new_title}')"
+                            )
+                            try:
+                                self.update_release_blog_info(
+                                    release['release_item_id'], new_title, new_url, new_distance
+                                )
+                            except Exception:
+                                if committer.connection is not self.conn:
+                                    committer.replace_connection(self.conn)
+                                raise
+
+                            if committer.connection is not self.conn:
+                                committer.replace_connection(self.conn)
+
+                            committer.mark_success()
+                            improved_count += 1
+
+                    except Exception as e:
+                        logger.error(f"Error reranking release {release['release_item_id']}: {e}")
 
             logger.info("=" * 60)
             logger.info(f"Reranking complete! {improved_count} matches improved out of {len(releases)} checked")

--- a/tests/test_batch_commit.py
+++ b/tests/test_batch_commit.py
@@ -1,0 +1,247 @@
+"""Tests for the batch-commit helper used by the vectorize/match pipelines.
+
+Covers:
+    * Happy path: ``mark_success`` commits exactly every N items.
+    * Final partial batch flushed on context-manager exit.
+    * Empty input does not commit.
+    * A failed item (exception path, no ``mark_success``) does not advance
+      the counter and does not get committed.
+    * Mid-batch reconnect (transient retry) drops the in-flight pending
+      counter and points subsequent commits at the new connection.
+    * Exception in the ``with`` block triggers rollback, not flush.
+    * ``get_batch_commit_size`` env-var resolution: default, override,
+      empty, non-numeric, non-positive.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from lib.batch_commit import (
+    BATCH_COMMIT_SIZE_ENV,
+    DEFAULT_BATCH_COMMIT_SIZE,
+    BatchCommitter,
+    get_batch_commit_size,
+)
+
+
+class FakeConn:
+    """Minimal pyodbc.Connection stand-in that records commit/rollback calls."""
+
+    def __init__(self):
+        self.commits = 0
+        self.rollbacks = 0
+        self.commit_should_raise = False
+
+    def commit(self):
+        if self.commit_should_raise:
+            raise RuntimeError("boom")
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+# --- BatchCommitter ----------------------------------------------------------
+
+
+def test_commits_every_n_items():
+    conn = FakeConn()
+    with BatchCommitter(conn, batch_size=3) as bc:
+        for _ in range(7):
+            bc.mark_success()
+        assert conn.commits == 2
+        assert bc.pending == 1
+    assert conn.commits == 3
+    assert bc.pending == 0
+    assert bc.committed == 7
+
+
+def test_final_partial_batch_flushed_on_exit():
+    conn = FakeConn()
+    with BatchCommitter(conn, batch_size=25) as bc:
+        for _ in range(4):
+            bc.mark_success()
+        assert conn.commits == 0
+    assert conn.commits == 1
+    assert bc.committed == 4
+
+
+def test_empty_batch_does_not_commit():
+    conn = FakeConn()
+    with BatchCommitter(conn, batch_size=25):
+        pass
+    assert conn.commits == 0
+    assert conn.rollbacks == 0
+
+
+def test_failed_item_is_skipped_and_not_committed():
+    """Per-item failures don't call mark_success; counter must not advance."""
+    conn = FakeConn()
+    items = ["good", "bad", "good", "good"]
+    with BatchCommitter(conn, batch_size=2) as bc:
+        for item in items:
+            try:
+                if item == "bad":
+                    raise ValueError("simulated per-item failure")
+                bc.mark_success()
+            except ValueError:
+                continue
+        assert conn.commits == 1
+        assert bc.pending == 1
+    assert conn.commits == 2
+    assert bc.committed == 3
+
+
+def test_exception_in_with_block_rolls_back_pending():
+    conn = FakeConn()
+    with pytest.raises(RuntimeError):
+        with BatchCommitter(conn, batch_size=10) as bc:
+            bc.mark_success()
+            bc.mark_success()
+            raise RuntimeError("kaboom")
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+def test_exception_with_no_pending_still_safe():
+    conn = FakeConn()
+    with pytest.raises(ValueError):
+        with BatchCommitter(conn, batch_size=10):
+            raise ValueError("nope")
+    assert conn.commits == 0
+    assert conn.rollbacks == 0
+
+
+def test_replace_connection_drops_in_flight_pending():
+    """Mid-batch reconnect (transient retry) loses pending in-flight items."""
+    old_conn = FakeConn()
+    new_conn = FakeConn()
+    with BatchCommitter(old_conn, batch_size=10) as bc:
+        bc.mark_success()
+        bc.mark_success()
+        lost = bc.replace_connection(new_conn)
+        assert lost == 2
+        assert bc.pending == 0
+        assert bc.connection is new_conn
+        bc.mark_success()
+    assert old_conn.commits == 0
+    assert new_conn.commits == 1
+    assert new_conn.rollbacks == 0
+
+
+def test_replace_connection_on_clean_boundary_returns_zero():
+    old_conn = FakeConn()
+    new_conn = FakeConn()
+    bc = BatchCommitter(old_conn, batch_size=5)
+    assert bc.replace_connection(new_conn) == 0
+
+
+def test_flush_is_idempotent_when_nothing_pending():
+    conn = FakeConn()
+    bc = BatchCommitter(conn, batch_size=5)
+    bc.flush()
+    bc.flush()
+    assert conn.commits == 0
+
+
+def test_rollback_pending_returns_count_and_clears_state():
+    conn = FakeConn()
+    bc = BatchCommitter(conn, batch_size=10)
+    bc.mark_success()
+    bc.mark_success()
+    bc.mark_success()
+    dropped = bc.rollback_pending()
+    assert dropped == 3
+    assert bc.pending == 0
+    assert conn.rollbacks == 1
+
+
+def test_rollback_pending_swallows_connection_errors():
+    """A dead connection's rollback() must not propagate out of the helper."""
+    conn = FakeConn()
+
+    def boom():
+        raise RuntimeError("connection already dead")
+
+    conn.rollback = boom  # type: ignore[assignment]
+    bc = BatchCommitter(conn, batch_size=10)
+    bc.mark_success()
+    bc.rollback_pending()
+    assert bc.pending == 0
+
+
+def test_invalid_batch_size_rejected():
+    conn = FakeConn()
+    with pytest.raises(ValueError):
+        BatchCommitter(conn, batch_size=0)
+    with pytest.raises(ValueError):
+        BatchCommitter(conn, batch_size=-3)
+
+
+def test_on_commit_callback_invoked_with_batch_size():
+    conn = FakeConn()
+    seen = []
+    with BatchCommitter(conn, batch_size=2, on_commit=seen.append) as bc:
+        bc.mark_success()
+        bc.mark_success()  # commits 2
+        bc.mark_success()  # 1 pending
+    assert seen == [2, 1]
+
+
+def test_on_commit_callback_failure_does_not_break_batch():
+    conn = FakeConn()
+
+    def bad_cb(_n):
+        raise RuntimeError("callback exploded")
+
+    with BatchCommitter(conn, batch_size=2, on_commit=bad_cb) as bc:
+        bc.mark_success()
+        bc.mark_success()  # triggers commit + callback
+        bc.mark_success()
+    assert conn.commits == 2
+    assert bc.committed == 3
+
+
+# --- get_batch_commit_size ---------------------------------------------------
+
+
+def test_get_batch_commit_size_default_when_unset():
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(BATCH_COMMIT_SIZE_ENV, None)
+        assert get_batch_commit_size() == DEFAULT_BATCH_COMMIT_SIZE
+
+
+def test_get_batch_commit_size_respects_env_override():
+    with mock.patch.dict(os.environ, {BATCH_COMMIT_SIZE_ENV: "50"}):
+        assert get_batch_commit_size() == 50
+
+
+def test_get_batch_commit_size_strips_whitespace():
+    with mock.patch.dict(os.environ, {BATCH_COMMIT_SIZE_ENV: "  10  "}):
+        assert get_batch_commit_size() == 10
+
+
+def test_get_batch_commit_size_falls_back_on_empty():
+    with mock.patch.dict(os.environ, {BATCH_COMMIT_SIZE_ENV: ""}):
+        assert get_batch_commit_size(default=7) == 7
+
+
+def test_get_batch_commit_size_falls_back_on_non_numeric():
+    with mock.patch.dict(os.environ, {BATCH_COMMIT_SIZE_ENV: "lots"}):
+        assert get_batch_commit_size(default=12) == 12
+
+
+def test_get_batch_commit_size_falls_back_on_non_positive():
+    with mock.patch.dict(os.environ, {BATCH_COMMIT_SIZE_ENV: "0"}):
+        assert get_batch_commit_size(default=9) == 9
+    with mock.patch.dict(os.environ, {BATCH_COMMIT_SIZE_ENV: "-5"}):
+        assert get_batch_commit_size(default=9) == 9
+
+
+def test_get_batch_commit_size_custom_env_var_name():
+    with mock.patch.dict(os.environ, {"MY_COMMIT_N": "11"}):
+        assert get_batch_commit_size(env_var="MY_COMMIT_N") == 11

--- a/tests/test_pipeline_batching.py
+++ b/tests/test_pipeline_batching.py
@@ -1,0 +1,167 @@
+"""Pipeline-level regression tests for issue #76 (batch commits).
+
+These assertions would have failed against ``main`` before the refactor:
+    * ``BlogVectorizer.update_post_vector`` used to ``conn.commit()`` itself
+      and use a brand-new connection per call. After the fix it must reuse
+      ``self.conn`` and leave commit timing to the BatchCommitter.
+    * ``vectorize_all_posts`` over N items must produce exactly ⌈N/B⌉
+      commits, not N commits.
+    * A single per-item failure must not abort the batch.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+# Stub out optional Azure SDKs the module imports at module load time so
+# the test environment doesn't need them. Only inject if missing.
+for missing in ("openai",):
+    if missing not in sys.modules:
+        stub = types.ModuleType(missing)
+        stub.AzureOpenAI = lambda **kwargs: None  # type: ignore[attr-defined]
+        sys.modules[missing] = stub
+
+
+@pytest.fixture
+def env_setup(monkeypatch):
+    monkeypatch.setenv("SQLSERVER_CONN", "DRIVER=stub")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://stub")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "stub")
+    monkeypatch.delenv("BATCH_COMMIT_SIZE", raising=False)
+    yield
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.executed = []
+        self.fetch_rows = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        self.conn.executions += 1
+        return self
+
+    def fetchall(self):
+        return self.fetch_rows
+
+    def fetchone(self):
+        return self.fetch_rows[0] if self.fetch_rows else None
+
+    def close(self):
+        pass
+
+
+class FakeConn:
+    def __init__(self):
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.executions = 0
+        self._cursor = None
+
+    def cursor(self):
+        if self._cursor is None:
+            self._cursor = FakeCursor(self)
+        return self._cursor
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+class FakeEmbeddingResponse:
+    def model_dump_json(self):
+        return '{"data":[{"embedding":[0.1,0.2]}]}'
+
+
+def _load_vectorizer_module():
+    import importlib
+
+    if "vectorize_blog_posts" in sys.modules:
+        del sys.modules["vectorize_blog_posts"]
+    return importlib.import_module("vectorize_blog_posts")
+
+
+def test_update_post_vector_does_not_commit_per_call(env_setup):
+    mod = _load_vectorizer_module()
+    fake_conn = FakeConn()
+
+    with mock.patch.object(mod.pyodbc, "connect", return_value=fake_conn):
+        v = mod.BlogVectorizer()
+        v.update_post_vector(post_id=42, embedding=FakeEmbeddingResponse())
+
+    # Regression: pre-#76 this was 1 (per-item commit). Now must be 0 —
+    # commits are deferred to BatchCommitter.
+    assert fake_conn.commits == 0
+    assert fake_conn.executions == 1
+
+
+def test_vectorize_all_posts_commits_once_per_batch(env_setup, monkeypatch):
+    monkeypatch.setenv("BATCH_COMMIT_SIZE", "3")
+    mod = _load_vectorizer_module()
+
+    fake_conn = FakeConn()
+    cur = fake_conn.cursor()
+    cur.fetch_rows = [
+        (i, f"title-{i}", "cat", "summary", "https://example.com")
+        for i in range(1, 8)
+    ]
+
+    with mock.patch.object(mod.pyodbc, "connect", return_value=fake_conn):
+        v = mod.BlogVectorizer()
+        v.generate_embedding = lambda text: FakeEmbeddingResponse()  # type: ignore[assignment]
+        v.vectorize_all_posts()
+
+    # 7 items, batch_size=3 → commits at 3, 6, and final flush of 1 == 3 commits
+    assert fake_conn.commits == 3
+
+
+def test_vectorize_per_item_failure_does_not_abort_batch(env_setup, monkeypatch):
+    monkeypatch.setenv("BATCH_COMMIT_SIZE", "10")
+    mod = _load_vectorizer_module()
+
+    fake_conn = FakeConn()
+    cur = fake_conn.cursor()
+    cur.fetch_rows = [
+        (i, f"title-{i}", "cat", "summary", "https://example.com")
+        for i in range(1, 5)
+    ]
+
+    with mock.patch.object(mod.pyodbc, "connect", return_value=fake_conn):
+        v = mod.BlogVectorizer()
+
+        def gen(text):
+            if "title-2" in text:
+                return None
+            return FakeEmbeddingResponse()
+
+        v.generate_embedding = gen  # type: ignore[assignment]
+        v.vectorize_all_posts()
+
+    # 4 posts, 1 failed embedding, so 3 UPDATEs succeed.
+    # batch_size=10 means a single final flush == 1 commit.
+    assert fake_conn.commits == 1
+
+
+def test_vectorize_no_posts_does_not_commit(env_setup):
+    mod = _load_vectorizer_module()
+
+    fake_conn = FakeConn()
+    cur = fake_conn.cursor()
+    cur.fetch_rows = []
+
+    with mock.patch.object(mod.pyodbc, "connect", return_value=fake_conn):
+        v = mod.BlogVectorizer()
+        v.vectorize_all_posts()
+
+    assert fake_conn.commits == 0

--- a/vectorize_blog_posts.py
+++ b/vectorize_blog_posts.py
@@ -12,7 +12,8 @@ from typing import List, Dict, Optional
 import pyodbc
 from openai import AzureOpenAI
 
-from lib.db_retry import retry_on_transient_errors
+from lib.batch_commit import BatchCommitter, get_batch_commit_size
+from lib.db_retry import retry_on_transient_errors, is_transient_sql_azure_error
 from lib.telemetry import init_telemetry
 
 # Configure logging
@@ -51,8 +52,38 @@ class BlogVectorizer:
             api_key=self.azure_api_key,
             api_version="2024-02-01"
         )
-        
+
+        # Long-lived DB connection for the batch loop (issue #76).
+        self.conn = None
+        self.cursor = None
+
         logger.info("BlogVectorizer initialized successfully")
+
+    def connect(self):
+        """Establish (or re-establish) the long-lived batch connection."""
+        if self.conn is None:
+            self.conn = pyodbc.connect(self.connection_string)
+            self.cursor = self.conn.cursor()
+            logger.info("Database connection established")
+
+    def close(self):
+        """Close the long-lived batch connection (best effort)."""
+        try:
+            if self.cursor is not None:
+                self.cursor.close()
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+        try:
+            if self.conn is not None:
+                self.conn.close()
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+        self.cursor = None
+        self.conn = None
+
+    def _drop_connection_silently(self):
+        """Tear down the connection so the next attempt reconnects."""
+        self.close()
     
     @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def get_posts_without_vectors(self) -> List[Dict]:
@@ -62,11 +93,8 @@ class BlogVectorizer:
         Returns:
             List of dictionaries containing post data
         """
-        conn = None
-        cursor = None
         try:
-            conn = pyodbc.connect(self.connection_string)
-            cursor = conn.cursor()
+            self.connect()
 
             query = """
             SELECT id, title, categories, summary, url
@@ -75,8 +103,8 @@ class BlogVectorizer:
             ORDER BY post_date DESC
             """
 
-            cursor.execute(query)
-            rows = cursor.fetchall()
+            self.cursor.execute(query)
+            rows = self.cursor.fetchall()
 
             posts = []
             for row in rows:
@@ -90,17 +118,10 @@ class BlogVectorizer:
 
             logger.info(f"Found {len(posts)} posts without vectors")
             return posts
-        finally:
-            if cursor is not None:
-                try:
-                    cursor.close()
-                except Exception:  # noqa: BLE001 — best-effort cleanup
-                    pass
-            if conn is not None:
-                try:
-                    conn.close()
-                except Exception:  # noqa: BLE001 — best-effort cleanup
-                    pass
+        except Exception as exc:
+            if is_transient_sql_azure_error(exc):
+                self._drop_connection_silently()
+            raise
     
     def create_text_for_embedding(self, post: Dict) -> str:
         """
@@ -161,93 +182,110 @@ class BlogVectorizer:
     @retry_on_transient_errors(max_attempts=3, initial_delay=0.5, backoff=2.0, max_delay=10.0)
     def update_post_vector(self, post_id: int, embedding) -> bool:
         """
-        Update the blog_vector column for a specific post
+        Execute (but do NOT commit) the blog_vector UPDATE for a specific post.
+
+        The commit is deferred to the surrounding ``BatchCommitter`` so the
+        pipeline pays one ``COMMIT`` round-trip per N items instead of one
+        per row (issue #76). On a transient SQL error this drops the shared
+        connection so the retry decorator's next attempt establishes a fresh
+        one before re-running the statement.
 
         Args:
             post_id: Database ID of the post
-            vector: Embedding vector to store
+            embedding: OpenAI embedding response object
 
         Returns:
-            True if successful. Raises on database error after retry exhaustion;
-            the caller is expected to catch and count as a failure.
+            True on success. Raises after retry exhaustion; the caller is
+            expected to catch and count as a failure.
         """
-        conn = None
-        cursor = None
         try:
-            conn = pyodbc.connect(self.connection_string)
-            cursor = conn.cursor()
+            self.connect()
 
             update_sql = """
             UPDATE fabric_blog_posts SET blog_vector = JSON_QUERY(CAST(? AS NVARCHAR(MAX)), '$.data[0].embedding') WHERE id = ?
             """
 
-            cursor.execute(update_sql, (embedding.model_dump_json(), post_id))
-            conn.commit()
+            self.cursor.execute(update_sql, (embedding.model_dump_json(), post_id))
             return True
-        finally:
-            if cursor is not None:
-                try:
-                    cursor.close()
-                except Exception:  # noqa: BLE001 — best-effort cleanup
-                    pass
-            if conn is not None:
-                try:
-                    conn.close()
-                except Exception:  # noqa: BLE001 — best-effort cleanup
-                    pass
+        except Exception as exc:
+            if is_transient_sql_azure_error(exc):
+                self._drop_connection_silently()
+            raise
     
-    def vectorize_all_posts(self, batch_size: int = 10):
+    def vectorize_all_posts(self, batch_size: Optional[int] = None):
         """
         Main method to vectorize all posts without vectors
-        
+
         Args:
-            batch_size: Number of posts to commit at once
+            batch_size: Number of successful items to commit at once. Defaults
+                to ``BATCH_COMMIT_SIZE`` env var (or 25).
         """
         try:
             # Get posts without vectors
             posts = self.get_posts_without_vectors()
-            
+
             if not posts:
                 logger.info("No posts found that need vectorization")
                 return
-            
-            logger.info(f"Starting vectorization of {len(posts)} posts")
-            
+
+            commit_size = batch_size if batch_size is not None else get_batch_commit_size()
+            logger.info(
+                f"Starting vectorization of {len(posts)} posts (commit every {commit_size})"
+            )
+
             success_count = 0
             failure_count = 0
-            
-            for i, post in enumerate(posts, 1):
-                try:
-                    logger.info(f"Processing post {i}/{len(posts)}: {post['title']}")
-                    
-                    # Create combined text
-                    text = self.create_text_for_embedding(post)
-                    
-                    if not text.strip():
-                        logger.warning(f"Skipping post ID {post['id']} - no content to vectorize")
-                        failure_count += 1
-                        continue
-                    
-                    # Generate embedding
-                    embedding = self.generate_embedding(text)
-                    
-                    if not embedding:
-                        logger.error(f"Failed to generate embedding for post ID {post['id']}")
-                        failure_count += 1
-                        continue
-                    
-                    # Update database
-                    if self.update_post_vector(post['id'], embedding):
+
+            self.connect()
+            with BatchCommitter(self.conn, batch_size=commit_size) as committer:
+                for i, post in enumerate(posts, 1):
+                    try:
+                        logger.info(f"Processing post {i}/{len(posts)}: {post['title']}")
+
+                        # Create combined text
+                        text = self.create_text_for_embedding(post)
+
+                        if not text.strip():
+                            logger.warning(f"Skipping post ID {post['id']} - no content to vectorize")
+                            failure_count += 1
+                            continue
+
+                        # Generate embedding (API errors must NOT poison the SQL conn)
+                        embedding = self.generate_embedding(text)
+
+                        if not embedding:
+                            logger.error(f"Failed to generate embedding for post ID {post['id']}")
+                            failure_count += 1
+                            continue
+
+                        # Stage the UPDATE on the shared connection. Commit is
+                        # deferred to the BatchCommitter (every N items).
+                        try:
+                            self.update_post_vector(post['id'], embedding)
+                        except Exception as e:
+                            # The retry decorator may have reconnected mid-batch;
+                            # if so, refresh the committer's connection so the
+                            # next commit targets the live one (and we drop the
+                            # in-flight transaction's pending counter).
+                            if committer.connection is not self.conn:
+                                committer.replace_connection(self.conn)
+                            logger.error(f"✗ Failed to update vector for post ID {post['id']}: {e}")
+                            failure_count += 1
+                            continue
+
+                        # The retry path may have swapped the connection; keep
+                        # the committer pointed at the live one.
+                        if committer.connection is not self.conn:
+                            committer.replace_connection(self.conn)
+
+                        committer.mark_success()
                         success_count += 1
                         logger.info(f"✓ Successfully vectorized post ID {post['id']}")
-                    else:
+
+                    except Exception as e:
+                        logger.error(f"Error processing post ID {post['id']}: {e}")
                         failure_count += 1
-                        logger.error(f"✗ Failed to update vector for post ID {post['id']}")
-                
-                except Exception as e:
-                    logger.error(f"Error processing post ID {post['id']}: {e}")
-                    failure_count += 1
-            
+
             # Final summary
             logger.info("=" * 60)
             logger.info(f"Vectorization complete!")
@@ -255,7 +293,7 @@ class BlogVectorizer:
             logger.info(f"Failed: {failure_count}")
             logger.info(f"Total processed: {len(posts)}")
             logger.info("=" * 60)
-        
+
         except Exception as e:
             logger.error(f"Fatal error during vectorization: {e}")
             raise
@@ -263,13 +301,17 @@ class BlogVectorizer:
 
 def main():
     """Main entry point"""
+    vectorizer = None
     try:
         vectorizer = BlogVectorizer()
         vectorizer.vectorize_all_posts()
-    
+
     except Exception as e:
         logger.error(f"Script failed: {e}")
         sys.exit(1)
+    finally:
+        if vectorizer is not None:
+            vectorizer.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Reduce per-item DB round-trips in the vectorize/match pipeline scripts. Closes #76.

Both `vectorize_blog_posts.py` and `match_releases_to_blogs.py` used to open a fresh `pyodbc` connection and `COMMIT` per row. With 100+ items per refresh that meant 100+ TLS + auth handshakes against Azure SQL on every cold run, plus pool churn.

After this change, each script holds a single long-lived connection across the batch loop and commits every **N=25** successful items (configurable via the `BATCH_COMMIT_SIZE` env var). For a 100-item run that's 4 commits instead of 100 — one round-trip per ~25 rows.

## How

New helper `lib/batch_commit.py`:
- `BatchCommitter(conn, batch_size=25)` context manager — `mark_success()` increments a pending counter and triggers `conn.commit()` every N items; `__exit__` flushes any partial batch on success or `rollback()`s on exception.
- `replace_connection(new_conn)` — swap to a fresh connection after a transient-retry reconnect; the in-flight `pending` counter is reset (and logged) because the prior transaction died with the old connection.
- `get_batch_commit_size()` — env-var resolver, falls back to default on unset / empty / non-numeric / non-positive values.

Refactor of both pipeline scripts:
- One `pyodbc.connect()` per script run instead of one per row.
- `update_post_vector` / `update_release_vector` / `update_release_blog_info` no longer call `commit()`; they just `execute()` against the shared cursor. The `BatchCommitter` owns commit timing.
- After each retry-decorated call, the loop checks `if committer.connection is not self.conn` and calls `replace_connection()` so subsequent commits target the live connection.
- Per-item embedding-API errors and per-item SQL errors are caught and counted as failures without aborting the batch.

## Per-item retry preservation (PR #67)

The retry behavior from #67 is preserved end-to-end:
- `update_*_vector` is still wrapped in `@retry_on_transient_errors`.
- On a transient SQL error the script drops the shared connection (`_drop_connection_silently()`); the retry decorator's next attempt calls `connect()` again, which establishes a fresh connection and re-runs the statement.
- The batch loop then notices `committer.connection is not self.conn` and calls `committer.replace_connection(self.conn)` so the next commit hits the new connection. The `pending` counter resets because the old transaction died with the old connection.

**Documented trade-off** (in `lib/batch_commit.py` module docstring): a transient connection failure mid-batch loses the *uncommitted* items in that batch window. Those rows revert to `WHERE x_vector IS NULL` and get re-processed on the next pipeline run — the pipeline is idempotent, so this delays work, it doesn't lose it. `N=25` keeps the worst-case re-work small.

## Tests

Two new test files, **+25 tests**, all running against mocked `pyodbc` connections (no live SQL):

`tests/test_batch_commit.py` — unit tests for the helper:
- Commits exactly every N items
- Final partial batch flushed on `__exit__`
- Empty input does not commit
- Failed items (no `mark_success`) don't advance the counter
- Exception in `with` block triggers `rollback()`, not `flush()`
- Mid-batch `replace_connection()` drops in-flight pending count and routes subsequent commits to the new connection
- `flush()` / `rollback_pending()` idempotent; rollback survives a dead connection
- `on_commit` callback errors don't poison the batch
- `get_batch_commit_size` env-var resolution: default / override / whitespace / empty / non-numeric / non-positive / custom var name

`tests/test_pipeline_batching.py` — pipeline-level regression tests that would have failed against `main`:
- `update_post_vector` no longer commits per call (was 1 commit, now 0)
- 7 items with `BATCH_COMMIT_SIZE=3` → exactly 3 commits (was 7)
- A failed embedding mid-batch does not abort the rest
- Empty post list → 0 commits

```
181 passed in 3.41s   (156 baseline + 25 new)
```

## Files

- `lib/batch_commit.py` (new, +180 LOC)
- `vectorize_blog_posts.py` (refactored)
- `match_releases_to_blogs.py` (refactored)
- `tests/test_batch_commit.py` (new)
- `tests/test_pipeline_batching.py` (new)

## Risk / rollback

- Failure mode: a transient SQL error mid-batch loses up to `BATCH_COMMIT_SIZE-1` uncommitted rows. They get re-processed on the next pipeline run. Set `BATCH_COMMIT_SIZE=1` to revert to per-item commit behavior without a code change.
- No schema changes, no API changes, no env-var changes required (`BATCH_COMMIT_SIZE` is optional).
