### PR TITLE
Extract generic SlidingWindowLimiter and apply to blog scraper (M15)

### DIFF
--- a/lib/rate_limit.py
+++ b/lib/rate_limit.py
@@ -1,0 +1,144 @@
+"""Generic in-process sliding-window rate limiter.
+
+This module is intentionally decoupled from any specific transport (HTTP,
+SMTP, Azure Communication Services, ...). Callers wrap each outbound
+operation in a ``wait_for_capacity()`` / ``record()`` pair:
+
+    limiter = SlidingWindowLimiter(max_calls=30, window_seconds=60)
+    for url in urls:
+        limiter.wait_for_capacity()
+        do_request(url)
+        limiter.record()
+
+The ``sleep`` and ``monotonic`` callables are injectable so tests can
+drive the clock deterministically without ``time.sleep`` actually pausing.
+
+This is the generic primitive intended for reuse across the codebase.
+``lib/acs_rate_limit.py`` (introduced in PR #80) carries the same
+shape with ACS-specific defaults; once both PRs land it can be reduced
+to a thin adapter on top of this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from typing import Callable, Deque, Optional
+
+
+class QuotaExceeded(RuntimeError):
+    """Raised when ``wait_for_capacity`` exceeds its caller-supplied timeout."""
+
+
+class SlidingWindowLimiter:
+    """True rolling sliding-window rate limiter.
+
+    Unlike a fixed-window counter (which permits bursts at the window
+    boundary), this implementation tracks the timestamp of every recorded
+    call inside the current window. Capacity is recovered as soon as the
+    oldest call ages past ``window_seconds`` ago.
+
+    A separate ``min_interval_seconds`` enforces a minimum gap between
+    consecutive calls and is checked after the window quota.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_calls: int,
+        window_seconds: float,
+        min_interval_seconds: float = 0.0,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        if max_calls <= 0:
+            raise ValueError("max_calls must be positive")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        if min_interval_seconds < 0:
+            raise ValueError("min_interval_seconds must be non-negative")
+
+        self._max_calls = max_calls
+        self._window_seconds = float(window_seconds)
+        self._min_interval = float(min_interval_seconds)
+        self._sleep = sleep
+        self._monotonic = monotonic
+        self._logger = logger or logging.getLogger(__name__)
+
+        self._calls: Deque[float] = deque()
+        self._last_call_time: float = float("-inf")
+
+    # ------------------------------------------------------------------
+    # Introspection helpers (mostly for tests / metrics)
+    # ------------------------------------------------------------------
+    @property
+    def max_calls(self) -> int:
+        return self._max_calls
+
+    @property
+    def window_seconds(self) -> float:
+        return self._window_seconds
+
+    @property
+    def min_interval_seconds(self) -> float:
+        return self._min_interval
+
+    def current_load(self) -> int:
+        """Return the number of calls counted inside the current window."""
+        self._evict_expired(self._monotonic())
+        return len(self._calls)
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+    def wait_for_capacity(self, *, timeout: Optional[float] = None) -> None:
+        """Block until the next call would respect both quotas.
+
+        Args:
+            timeout: Maximum time, in seconds, to wait. ``None`` waits
+                indefinitely. If the cumulative wait would exceed
+                ``timeout``, raises :class:`QuotaExceeded` without
+                sleeping further.
+        """
+        deadline = None if timeout is None else self._monotonic() + timeout
+
+        while True:
+            now = self._monotonic()
+            self._evict_expired(now)
+
+            wait = 0.0
+            if len(self._calls) >= self._max_calls:
+                # Window full: wait until the oldest call ages out.
+                wait = max(wait, self._calls[0] + self._window_seconds - now)
+
+            if self._min_interval > 0 and self._last_call_time > float("-inf"):
+                gap = now - self._last_call_time
+                if gap < self._min_interval:
+                    wait = max(wait, self._min_interval - gap)
+
+            if wait <= 0:
+                return
+
+            if deadline is not None and now + wait > deadline:
+                raise QuotaExceeded(
+                    f"Rate limit wait of {wait:.2f}s exceeds timeout"
+                )
+
+            self._logger.debug("rate-limit sleeping %.3fs", wait)
+            self._sleep(wait)
+
+    def record(self) -> None:
+        """Record that one call just completed."""
+        now = self._monotonic()
+        self._calls.append(now)
+        self._last_call_time = now
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _evict_expired(self, now: float) -> None:
+        cutoff = now - self._window_seconds
+        while self._calls and self._calls[0] <= cutoff:
+            self._calls.popleft()

--- a/scrape_fabric_blog.py
+++ b/scrape_fabric_blog.py
@@ -22,7 +22,25 @@ import xml.etree.ElementTree as ET
 import html
 
 from lib.db_retry import retry_on_transient_errors
+from lib.rate_limit import SlidingWindowLimiter
 from lib.telemetry import init_telemetry
+
+
+# Default rate-limit and backoff knobs. All overridable via env vars so
+# the refresh container can tune without a code change.
+DEFAULT_MAX_REQUESTS_PER_MINUTE = 30
+DEFAULT_MAX_RETRIES = 5
+DEFAULT_BACKOFF_BASE_SECONDS = 1.0
+DEFAULT_BACKOFF_MAX_SECONDS = 16.0
+
+
+def _build_default_limiter() -> SlidingWindowLimiter:
+    """Construct the limiter from env-var overrides."""
+    max_per_min = int(os.getenv(
+        'BLOG_SCRAPER_MAX_REQUESTS_PER_MINUTE',
+        str(DEFAULT_MAX_REQUESTS_PER_MINUTE),
+    ))
+    return SlidingWindowLimiter(max_calls=max_per_min, window_seconds=60.0)
 
 # Configure logging
 logging.basicConfig(
@@ -38,18 +56,81 @@ init_telemetry("fabric-gps-blog-scraper")
 class FabricBlogScraper:
     """Scrapes Microsoft Fabric blog posts and stores them in SQL Server"""
     
-    def __init__(self):
+    def __init__(self, rate_limiter: Optional[SlidingWindowLimiter] = None):
         self.base_url = "https://blog.fabric.microsoft.com/en-US/blog"
         self.rss_url = "https://blog.fabric.microsoft.com/en-us/blog/feed/"
         self.session = requests.Session()
         self.session.headers.update({
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
         })
-        
+
+        # In-process rate limiter shared across every outbound request
+        # this scraper makes (page list, RSS feed, individual articles).
+        self.rate_limiter = rate_limiter or _build_default_limiter()
+        self.max_retries = int(os.getenv(
+            'BLOG_SCRAPER_MAX_RETRIES', str(DEFAULT_MAX_RETRIES)
+        ))
+        self.backoff_base = float(os.getenv(
+            'BLOG_SCRAPER_BACKOFF_BASE', str(DEFAULT_BACKOFF_BASE_SECONDS)
+        ))
+        self.backoff_max = float(os.getenv(
+            'BLOG_SCRAPER_BACKOFF_MAX', str(DEFAULT_BACKOFF_MAX_SECONDS)
+        ))
+
         # Database connection from environment
         self.connection_string = os.getenv('SQLSERVER_CONN')
         if not self.connection_string:
             raise ValueError("SQLSERVER_CONN environment variable not set")
+
+    def _rate_limited_get(self, url: str, *, timeout: int = 30) -> requests.Response:
+        """GET ``url`` through the rate limiter with 429 exponential backoff.
+
+        Retries on HTTP 429 (and 503 — a similar back-off signal) with
+        exponential delays capped at ``self.backoff_max``. Honors
+        ``Retry-After`` if present. Other HTTPErrors fall through to the
+        caller via ``raise_for_status``.
+        """
+        attempt = 0
+        while True:
+            self.rate_limiter.wait_for_capacity()
+            response = self.session.get(url, timeout=timeout)
+
+            if response.status_code not in (429, 503):
+                # Only successful (or non-throttling-error) requests count
+                # against the local quota — otherwise repeated 429s would
+                # eat our budget and cascade into longer client-side waits
+                # on top of the server's backoff signal.
+                self.rate_limiter.record()
+                response.raise_for_status()
+                return response
+
+            if attempt >= self.max_retries:
+                logger.error(
+                    "Giving up on %s after %d retries (status=%s)",
+                    url, attempt, response.status_code,
+                )
+                self.rate_limiter.record()
+                response.raise_for_status()
+                return response
+
+            backoff = min(
+                self.backoff_max,
+                self.backoff_base * (2 ** attempt),
+            )
+            retry_after = response.headers.get('Retry-After')
+            if retry_after:
+                try:
+                    backoff = max(backoff, float(retry_after))
+                except ValueError:
+                    pass
+
+            logger.warning(
+                "HTTP %s on %s (attempt %d/%d) — sleeping %.1fs",
+                response.status_code, url, attempt + 1,
+                self.max_retries, backoff,
+            )
+            time.sleep(backoff)
+            attempt += 1
     
     def fetch_page(self, page_num: int) -> Optional[BeautifulSoup]:
         """
@@ -64,12 +145,7 @@ class FabricBlogScraper:
         url = f"{self.base_url}?page={page_num}"
         try:
             logger.info(f"Fetching page {page_num}: {url}")
-            response = self.session.get(url, timeout=30)
-            response.raise_for_status()
-            
-            # Add small delay to be respectful to the server
-            time.sleep(1)
-            
+            response = self._rate_limited_get(url)
             return BeautifulSoup(response.content, 'html.parser')
         
         except requests.RequestException as e:
@@ -354,9 +430,8 @@ class FabricBlogScraper:
         """
         try:
             logger.info(f"Fetching RSS feed: {self.rss_url}")
-            response = self.session.get(self.rss_url, timeout=30)
-            response.raise_for_status()
-            
+            response = self._rate_limited_get(self.rss_url)
+
             root = ET.fromstring(response.content)
             return root
         
@@ -462,9 +537,8 @@ class FabricBlogScraper:
         """
         try:
             logger.info(f"Fetching article details from: {url}")
-            response = self.session.get(url, timeout=30)
-            response.raise_for_status()
-            
+            response = self._rate_limited_get(url)
+
             soup = BeautifulSoup(response.content, 'html.parser')
             
             details = {
@@ -492,10 +566,7 @@ class FabricBlogScraper:
                         details['author'] = html.unescape(author_link.get_text(strip=True))
             
             logger.info(f"Extracted details - Categories: {details['categories']}, Author: {details['author']}")
-            
-            # Add small delay to be respectful to the server
-            time.sleep(1)
-            
+
             return details
         
         except requests.RequestException as e:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,215 @@
+"""Tests for ``lib/rate_limit.py``.
+
+Uses a fake clock and fake ``sleep`` (both injected via the limiter
+constructor) so the tests are fully deterministic and don't touch real
+time. ``freezegun`` isn't needed because the limiter only reads
+``monotonic`` through the injected callable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lib.rate_limit import QuotaExceeded, SlidingWindowLimiter
+
+
+class FakeClock:
+    """Monotonic clock + sleep that simply advance an internal counter."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        # Record what was requested then advance the clock.
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _make(clock: FakeClock, **kwargs) -> SlidingWindowLimiter:
+    defaults = dict(max_calls=3, window_seconds=60.0)
+    defaults.update(kwargs)
+    return SlidingWindowLimiter(
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+        **defaults,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction / validation
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(max_calls=0, window_seconds=60),
+        dict(max_calls=-1, window_seconds=60),
+        dict(max_calls=10, window_seconds=0),
+        dict(max_calls=10, window_seconds=-1),
+        dict(max_calls=10, window_seconds=60, min_interval_seconds=-0.1),
+    ],
+)
+def test_invalid_construction_raises(kwargs):
+    with pytest.raises(ValueError):
+        SlidingWindowLimiter(**kwargs)
+
+
+def test_properties_expose_config():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=5, window_seconds=30, min_interval_seconds=0.5)
+    assert limiter.max_calls == 5
+    assert limiter.window_seconds == 30.0
+    assert limiter.min_interval_seconds == 0.5
+    assert limiter.current_load() == 0
+
+
+# ---------------------------------------------------------------------------
+# Basic quota behavior
+# ---------------------------------------------------------------------------
+def test_under_quota_does_not_sleep():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=3, window_seconds=60)
+
+    for _ in range(3):
+        limiter.wait_for_capacity()
+        limiter.record()
+
+    assert clock.sleeps == []
+    assert limiter.current_load() == 3
+
+
+def test_burst_then_block_until_oldest_ages_out():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=3, window_seconds=60)
+
+    # Three calls at t=0, 1, 2 fill the window.
+    for i in range(3):
+        limiter.wait_for_capacity()
+        limiter.record()
+        clock.advance(1.0)
+    # clock now at t=3.
+
+    # 4th request must wait until the oldest call (t=0) is >60s old,
+    # i.e. until t=60. Currently t=3 → sleep for 57s.
+    limiter.wait_for_capacity()
+    assert clock.sleeps == [pytest.approx(57.0)]
+
+
+def test_capacity_recovers_as_calls_age_out():
+    """Sliding window: calls expire individually, not in a batch reset."""
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=2, window_seconds=10)
+
+    limiter.wait_for_capacity(); limiter.record()  # t=0
+    clock.advance(5)
+    limiter.wait_for_capacity(); limiter.record()  # t=5
+    assert limiter.current_load() == 2
+
+    # Advance to t=11: first call (t=0) has expired (>10s), second
+    # (t=5) has not. We should be able to fire one more without sleeping.
+    clock.advance(6)  # t=11
+    assert limiter.current_load() == 1
+    limiter.wait_for_capacity()
+    assert clock.sleeps == []  # no sleep needed
+
+
+def test_min_interval_enforced_between_calls():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=100, window_seconds=60, min_interval_seconds=2.0)
+
+    limiter.wait_for_capacity(); limiter.record()  # t=0
+    # No advance: next call should wait the full 2s.
+    limiter.wait_for_capacity()
+    assert clock.sleeps == [pytest.approx(2.0)]
+
+
+def test_min_interval_satisfied_when_enough_gap_already_elapsed():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=100, window_seconds=60, min_interval_seconds=2.0)
+
+    limiter.wait_for_capacity(); limiter.record()  # t=0
+    clock.advance(3.0)
+    limiter.wait_for_capacity()
+    assert clock.sleeps == []
+
+
+def test_min_interval_and_window_both_respected_picks_larger_wait():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=2, window_seconds=10, min_interval_seconds=1.0)
+
+    limiter.wait_for_capacity(); limiter.record()  # t=0
+    limiter.wait_for_capacity(); limiter.record()  # t=1 (slept 1.0)
+    # Window full. Oldest at t=0 ages out at t=10 → need to wait 9s
+    # from current t=1. min_interval would only ask for 1s.
+    limiter.wait_for_capacity()
+    assert clock.sleeps == [pytest.approx(1.0), pytest.approx(9.0)]
+
+
+# ---------------------------------------------------------------------------
+# Window-boundary semantics (the meat of "sliding")
+# ---------------------------------------------------------------------------
+def test_sustained_throughput_at_quota_no_extra_sleeps():
+    """Calling at exactly the quota rate should never block."""
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=10, window_seconds=60)
+
+    # 10 calls in the first second.
+    for _ in range(10):
+        limiter.wait_for_capacity(); limiter.record()
+        clock.advance(0.1)
+
+    # Wait one full window past the first call, then 10 more.
+    clock.advance(60)
+    sleeps_before = list(clock.sleeps)
+    for _ in range(10):
+        limiter.wait_for_capacity(); limiter.record()
+        clock.advance(0.1)
+
+    assert clock.sleeps == sleeps_before  # no new sleeps
+
+
+# ---------------------------------------------------------------------------
+# Timeout / QuotaExceeded
+# ---------------------------------------------------------------------------
+def test_timeout_raises_quota_exceeded_without_sleeping():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=1, window_seconds=60)
+
+    limiter.wait_for_capacity(); limiter.record()  # t=0, fills window
+
+    with pytest.raises(QuotaExceeded):
+        # Next call would need to wait ~60s, but we only allow 5s.
+        limiter.wait_for_capacity(timeout=5.0)
+    # No sleep should have been performed.
+    assert clock.sleeps == []
+
+
+def test_timeout_none_blocks_indefinitely():
+    clock = FakeClock()
+    limiter = _make(clock, max_calls=1, window_seconds=10)
+    limiter.wait_for_capacity(); limiter.record()
+    # Should not raise; should sleep ~10s.
+    limiter.wait_for_capacity(timeout=None)
+    assert clock.sleeps == [pytest.approx(10.0)]
+
+
+# ---------------------------------------------------------------------------
+# Logger plumbing
+# ---------------------------------------------------------------------------
+def test_custom_logger_is_used(caplog):
+    clock = FakeClock()
+    custom = logging.getLogger("rate_limit.test.custom")
+    limiter = _make(clock, max_calls=1, window_seconds=10, logger=custom)
+    limiter.wait_for_capacity(); limiter.record()
+
+    with caplog.at_level(logging.DEBUG, logger=custom.name):
+        limiter.wait_for_capacity()
+    assert any("rate-limit sleeping" in r.message for r in caplog.records)

--- a/tests/test_scrape_rate_limit.py
+++ b/tests/test_scrape_rate_limit.py
@@ -1,0 +1,147 @@
+"""Tests for ``scrape_fabric_blog._rate_limited_get``.
+
+We don't exercise the SQL-server side of the scraper here — that needs a
+live ODBC driver and a database. Instead we instantiate the scraper with
+the connection-string env var stubbed out and a fake limiter, then drive
+``_rate_limited_get`` against a mocked ``requests.Session``.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+
+@pytest.fixture
+def scraper_module():
+    os.environ.setdefault("SQLSERVER_CONN", "Driver={Test};Server=test;")
+    import scrape_fabric_blog
+    return scrape_fabric_blog
+
+
+@pytest.fixture
+def scraper(scraper_module):
+    from lib.rate_limit import SlidingWindowLimiter
+    s = scraper_module.FabricBlogScraper(
+        rate_limiter=SlidingWindowLimiter(max_calls=1000, window_seconds=60)
+    )
+    s.session = MagicMock()
+    s.rate_limiter = MagicMock(wraps=s.rate_limiter)
+    s.backoff_base = 0.0  # don't actually sleep in tests
+    s.backoff_max = 0.0
+    return s
+
+
+def _resp(status: int, body: bytes = b"<html/>", headers=None) -> MagicMock:
+    r = MagicMock(spec=requests.Response)
+    r.status_code = status
+    r.content = body
+    r.headers = headers or {}
+    if 400 <= status < 600:
+        r.raise_for_status.side_effect = requests.HTTPError(f"HTTP {status}", response=r)
+    else:
+        r.raise_for_status.return_value = None
+    return r
+
+
+def test_happy_path_calls_limiter_then_records(scraper):
+    scraper.session.get.return_value = _resp(200)
+
+    response = scraper._rate_limited_get("https://example.test/page")
+
+    assert response.status_code == 200
+    scraper.rate_limiter.wait_for_capacity.assert_called_once()
+    scraper.rate_limiter.record.assert_called_once()
+    scraper.session.get.assert_called_once_with("https://example.test/page", timeout=30)
+
+
+def test_429_then_200_retries_with_backoff(scraper):
+    scraper.session.get.side_effect = [_resp(429), _resp(200)]
+
+    with patch("scrape_fabric_blog.time.sleep") as mock_sleep:
+        response = scraper._rate_limited_get("https://example.test/page")
+
+    assert response.status_code == 200
+    assert scraper.session.get.call_count == 2
+    assert scraper.rate_limiter.wait_for_capacity.call_count == 2
+    # Failed (429) attempts do not consume client-side quota; only the
+    # final successful response is recorded.
+    assert scraper.rate_limiter.record.call_count == 1
+    # One backoff sleep between the two attempts.
+    assert mock_sleep.call_count == 1
+
+
+def test_503_also_triggers_backoff_retry(scraper):
+    scraper.session.get.side_effect = [_resp(503), _resp(200)]
+
+    with patch("scrape_fabric_blog.time.sleep"):
+        response = scraper._rate_limited_get("https://example.test/page")
+
+    assert response.status_code == 200
+    assert scraper.session.get.call_count == 2
+
+
+def test_retry_after_header_overrides_backoff(scraper):
+    scraper.backoff_base = 1.0
+    scraper.backoff_max = 1.0
+    scraper.session.get.side_effect = [
+        _resp(429, headers={"Retry-After": "7"}),
+        _resp(200),
+    ]
+
+    with patch("scrape_fabric_blog.time.sleep") as mock_sleep:
+        scraper._rate_limited_get("https://example.test/page")
+
+    # backoff floor is min(max=1.0, base*2**0=1.0)=1.0, but Retry-After
+    # bumps it to max(1.0, 7.0) = 7.0.
+    mock_sleep.assert_called_once_with(7.0)
+
+
+def test_429_exhausts_retries_then_raises(scraper):
+    scraper.max_retries = 2
+    scraper.session.get.return_value = _resp(429)
+
+    with patch("scrape_fabric_blog.time.sleep"):
+        with pytest.raises(requests.HTTPError):
+            scraper._rate_limited_get("https://example.test/page")
+
+    # Initial attempt + 2 retries = 3 GETs.
+    assert scraper.session.get.call_count == 3
+    # Only the terminal give-up call records against the limiter; the
+    # intermediate 429s do not.
+    assert scraper.rate_limiter.record.call_count == 1
+
+
+def test_non_retryable_4xx_does_not_retry(scraper):
+    scraper.session.get.return_value = _resp(404)
+
+    with pytest.raises(requests.HTTPError):
+        scraper._rate_limited_get("https://example.test/page")
+
+    assert scraper.session.get.call_count == 1
+    # Limiter should still have counted the call.
+    scraper.rate_limiter.wait_for_capacity.assert_called_once()
+    scraper.rate_limiter.record.assert_called_once()
+
+
+def test_fetch_page_uses_rate_limited_get(scraper):
+    scraper.session.get.return_value = _resp(
+        200, body=b"<html><body><article class='post'></article></body></html>"
+    )
+    soup = scraper.fetch_page(7)
+
+    assert soup is not None
+    scraper.rate_limiter.wait_for_capacity.assert_called_once()
+    scraper.rate_limiter.record.assert_called_once()
+    args, kwargs = scraper.session.get.call_args
+    assert "page=7" in args[0]
+
+
+def test_default_limiter_constructed_from_env(monkeypatch, scraper_module):
+    monkeypatch.setenv("BLOG_SCRAPER_MAX_REQUESTS_PER_MINUTE", "42")
+    limiter = scraper_module._build_default_limiter()
+    assert limiter.max_calls == 42
+    assert limiter.window_seconds == 60.0


### PR DESCRIPTION
## Summary

Closes #77.

Extracts a generic in-process sliding-window rate limiter to `lib/rate_limit.py` and wires it into `scrape_fabric_blog.py`, replacing three ad-hoc `time.sleep(1)` statements with proper per-minute quota tracking and HTTP 429/503 exponential backoff.

## Changes

| File | Lines | Notes |
|---|---:|---|
| `lib/rate_limit.py` (new) | 142 | Generic `SlidingWindowLimiter` + `QuotaExceeded` |
| `scrape_fabric_blog.py` | +73 / −10 | New `_rate_limited_get` helper; three call sites migrated |
| `tests/test_rate_limit.py` (new) | 17 tests | Limiter math, sliding-window aging, min_interval, timeout |
| `tests/test_scrape_rate_limit.py` (new) | 7 tests | Happy path, 429→200 retry, 503, Retry-After, max retries, non-retryable 4xx, env config |

## Design

- **True rolling window**, not fixed-window: each recorded call is timestamped in a `deque`, and capacity is recovered as soon as the oldest call ages past `window_seconds` ago. Avoids the burst-at-boundary artifact that fixed-window counters have.
- **Decoupled from any transport**: no HTTP / ACS / SQL knowledge in `lib/rate_limit.py`. The 429/503 backoff lives in the scraper, not the limiter.
- **Injectable `sleep` and `monotonic`** so tests are deterministic without `freezegun` or real `time.sleep`.
- **Failed requests don't consume client-side quota** — only successful (or terminally-failed) responses call `record()`. Prevents 429 cascades from eating our local budget on top of the server's backoff signal. (Caught in pre-push code review.)
- **Configurable via env vars**:
  - `BLOG_SCRAPER_MAX_REQUESTS_PER_MINUTE` (default 30)
  - `BLOG_SCRAPER_MAX_RETRIES` (default 5)
  - `BLOG_SCRAPER_BACKOFF_BASE` (default 1.0s) / `BLOG_SCRAPER_BACKOFF_MAX` (default 16s)
  - `Retry-After` header is honored when present.

## Coordination with PR #80

PR #80 (M5, weekly-email split) lands `lib/acs_rate_limit.py` first — a similar (but **fixed-window**) sliding-window limiter with ACS-specific defaults. To keep both PRs cleanly mergeable in either order, this PR **does not touch `lib/acs_rate_limit.py`**. The two implementations will coexist briefly.

**Follow-up after both #77 and #80 merge**: collapse `lib/acs_rate_limit.py` into a thin adapter on top of `lib/rate_limit.py` — keep `RateLimitConfig` + `acs_default_config()` as the public ACS-flavored API, but route the actual quota math through `SlidingWindowLimiter`. The constructor shapes were intentionally kept compatible so this is a small surgical change rather than a rewrite.

The `weekly_email_job.py` migration mentioned in #77 is also deferred to that follow-up — doing it here would conflict directly with PR #80's god-class split.

## Out of scope

- Migrating `weekly_email_job.py` to the new limiter (deferred to consolidation follow-up).
- Distributed rate limiting (we run a single refresh container, in-process is sufficient).
- Adding rate limiting to other outbound clients (`get_current_releases.py`, vectorizer) — none of them currently hammer external APIs.

## Verification

```powershell
.\.venv\Scripts\python.exe -m pytest -q
# 180 passed in 2.38s   (baseline on main: 156)
```

Test count delta: **+24** (17 limiter + 7 scraper integration).

Pre-push code review surfaced one high-signal issue (failed-attempt budget consumption) which has been fixed and re-tested.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
