### PR TITLE
M7: Finish routing pipeline scripts through lib.telemetry.init_telemetry

### DIFF
--- a/get_current_releases.py
+++ b/get_current_releases.py
@@ -2,7 +2,6 @@ import requests
 import re
 import unicodedata
 import json
-import logging
 import os
 
 from unidecode import unidecode
@@ -10,26 +9,9 @@ from unidecode import unidecode
 from lib.release_item import ReleaseItem
 from db.db_sqlserver import make_engine, init_db, save_releases, deactivate_missing_releases
 from lib.indexnow import submit_urls
-# Import the `configure_azure_monitor()` function from the
-# `azure.monitor.opentelemetry` package.
-from azure.monitor.opentelemetry import configure_azure_monitor
+from lib.telemetry import init_telemetry
 
-os.environ['OTEL_SERVICE_NAME'] = 'fabric-gps-refresh'
-
-logger_name = 'fabric-gps-refresh'
-
-opentelemetery_logger_name = f'{logger_name}.opentelemetry'
-
-if os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING") and os.getenv("CURRENT_ENVIRONMENT") != "development":
-    configure_azure_monitor(
-        logger_name=opentelemetery_logger_name,
-        enable_live_metrics=True 
-    )
-
-otelLogger= logging.getLogger(opentelemetery_logger_name)
-stream = logging.StreamHandler()
-otelLogger.addHandler(stream)
-otelLogger.setLevel(logging.INFO)
+otelLogger = init_telemetry("fabric-gps-refresh")
 otelLogger.info('Fabric-GPS Database Refresh started')
 
 def extract_product_families(js_text):

--- a/weekly_email_job.py
+++ b/weekly_email_job.py
@@ -19,14 +19,12 @@ should stay small enough to read top-to-bottom in a single pass.
 
 from __future__ import annotations
 
-import logging
 import os
 import sys
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from azure.communication.email import EmailClient
-from azure.monitor.opentelemetry import configure_azure_monitor
 
 # Add the project root to Python path so this script runs both as a
 # module and as ``python weekly_email_job.py``.
@@ -45,22 +43,12 @@ from db.db_sqlserver import (
 from lib.acs_rate_limit import SlidingWindowRateLimiter, acs_default_config
 from lib import email_template
 from lib.email_digest import DigestContentBuilder, filter_by_cadence
+from lib.telemetry import init_telemetry
 
-os.environ['OTEL_SERVICE_NAME'] = 'fabric-gps-email-job'
-
-logger_name = 'fabric-gps-email'
-opentelemetery_logger_name = f'{logger_name}.opentelemetry'
-
-if os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING") and os.getenv("CURRENT_ENVIRONMENT") != "development":
-    configure_azure_monitor(
-        logger_name=opentelemetery_logger_name,
-        enable_live_metrics=True,
-    )
-
-logger = logging.getLogger(opentelemetery_logger_name)
-stream = logging.StreamHandler()
-logger.addHandler(stream)
-logger.setLevel(logging.INFO)
+logger = init_telemetry(
+    "fabric-gps-email-job",
+    logger_name="fabric-gps-email.opentelemetry",
+)
 logger.info('Fabric-GPS Email Batch Job started')
 
 


### PR DESCRIPTION
# M7: Finish routing pipeline scripts through `lib.telemetry.init_telemetry`

Closes out **M7** from the code-quality review (`Inconsistent retry/observability across pipeline scripts`).

## Background

M7 called for a single `lib/telemetry.py::init_telemetry(service_name)` helper so every pipeline entrypoint emits OpenTelemetry to App Insights consistently. The helper itself, the wiring of the three previously-dark scripts (`vectorize_blog_posts.py`, `match_releases_to_blogs.py`, `scrape_fabric_blog.py`), and a comprehensive `tests/test_telemetry.py` (9 tests, all mocked — no Azure Monitor calls) shipped to `main` in a prior batch.

## What this PR does

Removes the now-duplicated inline `configure_azure_monitor` boilerplate from the two scripts that still had it and routes them through the shared helper:

- **`get_current_releases.py`** — uses helper defaults (service name `fabric-gps-refresh`, logger name `fabric-gps-refresh.opentelemetry`).
- **`weekly_email_job.py`** — passes an explicit `logger_name="fabric-gps-email.opentelemetry"` because this script has historically had its `OTEL_SERVICE_NAME` (`fabric-gps-email-job`) and logger name (`fabric-gps-email.opentelemetry`) intentionally diverge. Preserving the logger name avoids silently re-partitioning App Insights data.

## Why no new tests

`lib/telemetry.py` is already covered by `tests/test_telemetry.py` (9 tests merged in the prior commit), including:
- dev short-circuit
- prod env triggers init
- idempotency / no duplicate stream handlers
- `OTEL_SERVICE_NAME` is set
- service name and custom logger name are propagated to `configure_azure_monitor`

This PR is a pure call-site swap with identical observable behavior, so no additional tests are warranted.

## Verification

- `pytest -q` → **334 passed** (no count delta vs. main; this is a refactor)
- Diff is `-37 / +7` LOC across the two scripts
- Telemetry service + logger names verified identical pre/post
- `code-review` sub-agent run on the diff: no findings
