### PR TITLE
Consolidate acs_rate_limit onto generic SlidingWindowLimiter

### DIFF
--- a/lib/acs_rate_limit.py
+++ b/lib/acs_rate_limit.py
@@ -1,22 +1,25 @@
-"""Sliding-window rate limiter for outbound API calls.
+"""ACS-flavoured adapter over :mod:`lib.rate_limit`.
 
-Originally extracted from ``weekly_email_job.py`` where it was tangled into
-the digest-send loop. The implementation is intentionally generic — it
-knows nothing about Azure Communication Services beyond an
-``acs_default_config()`` factory that captures the current production
-quota. Issue #77 (M15) is expected to reuse this for the scraper, at
-which point this module can be promoted to ``lib/rate_limit.py`` without
-behaviour changes.
+This module used to carry its own sliding-window implementation
+(extracted from ``weekly_email_job.py`` in PR #80). PR #81 introduced
+the generic :class:`lib.rate_limit.SlidingWindowLimiter`, which already
+supports the two constraints we need:
 
-Two independent constraints are enforced:
+* ``min_interval_seconds`` — minimum gap between consecutive sends.
+* ``max_calls`` per ``window_seconds`` — rolling-window quota.
 
-* A minimum interval between sends (per-second / per-minute throttling).
-* A maximum number of sends per rolling window (e.g. 800 / hour).
+So this module is now just a thin shim that:
 
-The limiter is *blocking*: callers invoke :meth:`wait_for_capacity`
-before each send and :meth:`record_send` after a successful send. The
-``sleep`` and ``monotonic`` callables are injectable so tests can drive
-the clock deterministically without ``time.sleep`` actually pausing.
+1. Captures the production ACS quota in :func:`acs_default_config` and
+   :class:`RateLimitConfig` (kept as a frozen dataclass for stability /
+   readability at call sites).
+2. Wraps a :class:`SlidingWindowLimiter` behind the original
+   ``wait_for_capacity()`` / ``record_send()`` / ``window_sent`` API
+   that ``weekly_email_job.py`` was written against.
+
+The generic limiter's sliding-window semantics are a strict superset
+of the previous fixed-window behaviour (it is at least as conservative
+at every point in time), so existing ACS quota guarantees are preserved.
 """
 
 from __future__ import annotations
@@ -25,6 +28,8 @@ import logging
 import time
 from dataclasses import dataclass
 from typing import Callable, Optional
+
+from lib.rate_limit import SlidingWindowLimiter
 
 
 @dataclass(frozen=True)
@@ -62,12 +67,12 @@ def acs_default_config() -> RateLimitConfig:
 
 
 class SlidingWindowRateLimiter:
-    """Blocking sliding-window rate limiter.
+    """Blocking sliding-window rate limiter for ACS sends.
 
-    The window is *not* a true sliding window in the strict sense: it is
-    a fixed-length window that resets to zero once ``window_seconds`` has
-    elapsed since the window started. This matches the original
-    ``weekly_email_job.py`` semantics exactly.
+    Thin wrapper over :class:`lib.rate_limit.SlidingWindowLimiter` that
+    preserves the original ``wait_for_capacity`` / ``record_send`` API
+    used by ``weekly_email_job.py`` and adds the ``window_sent`` /
+    ``config`` introspection properties the existing tests rely on.
     """
 
     def __init__(
@@ -79,13 +84,14 @@ class SlidingWindowRateLimiter:
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._config = config
-        self._sleep = sleep
-        self._monotonic = monotonic
-        self._logger = logger or logging.getLogger(__name__)
-
-        self._last_send_time: float = 0.0
-        self._window_sent: int = 0
-        self._window_start: float = monotonic()
+        self._limiter = SlidingWindowLimiter(
+            max_calls=config.max_per_window,
+            window_seconds=config.window_seconds,
+            min_interval_seconds=config.min_interval_seconds,
+            sleep=sleep,
+            monotonic=monotonic,
+            logger=logger,
+        )
 
     @property
     def config(self) -> RateLimitConfig:
@@ -93,35 +99,12 @@ class SlidingWindowRateLimiter:
 
     @property
     def window_sent(self) -> int:
-        return self._window_sent
+        """Number of sends currently counted inside the rolling window."""
+        return self._limiter.current_load()
 
     def wait_for_capacity(self) -> None:
-        """Block until the next send would respect both quotas.
-
-        Order matters: the per-window check runs first (and may sleep
-        for a long time, possibly minutes), then the per-send minimum
-        interval is enforced.
-        """
-        now = self._monotonic()
-        elapsed_in_window = now - self._window_start
-        if elapsed_in_window >= self._config.window_seconds:
-            self._window_sent = 0
-            self._window_start = now
-        elif self._window_sent >= self._config.max_per_window:
-            wait_time = self._config.window_seconds - elapsed_in_window
-            self._logger.info(
-                "Hourly quota reached (%d), pausing %.0fs",
-                self._config.max_per_window,
-                wait_time,
-            )
-            if wait_time > 0:
-                self._sleep(wait_time)
-            self._window_sent = 0
-            self._window_start = self._monotonic()
-
-        elapsed = self._monotonic() - self._last_send_time
-        if elapsed < self._config.min_interval_seconds:
-            self._sleep(self._config.min_interval_seconds - elapsed)
+        """Block until the next send would respect both quotas."""
+        self._limiter.wait_for_capacity()
 
     def record_send(self) -> None:
         """Record that a send completed successfully.
@@ -130,5 +113,4 @@ class SlidingWindowRateLimiter:
         leave the counters untouched so a flapping ACS endpoint doesn't
         falsely consume budget.
         """
-        self._window_sent += 1
-        self._last_send_time = self._monotonic()
+        self._limiter.record()

--- a/lib/rate_limit.py
+++ b/lib/rate_limit.py
@@ -14,9 +14,9 @@ The ``sleep`` and ``monotonic`` callables are injectable so tests can
 drive the clock deterministically without ``time.sleep`` actually pausing.
 
 This is the generic primitive intended for reuse across the codebase.
-``lib/acs_rate_limit.py`` (introduced in PR #80) carries the same
-shape with ACS-specific defaults; once both PRs land it can be reduced
-to a thin adapter on top of this module.
+``lib/acs_rate_limit.py`` is a thin adapter on top of this module that
+carries ACS-specific defaults and the legacy
+``wait_for_capacity`` / ``record_send`` API used by the email job.
 """
 
 from __future__ import annotations

--- a/tests/test_acs_rate_limit.py
+++ b/tests/test_acs_rate_limit.py
@@ -98,11 +98,13 @@ class TestWindowQuota:
             lim.wait_for_capacity()
             lim.record_send()
             clock.advance(1.0)
-        # Window: started at 1000, three sends, last at 1002, now 1003.
-        # Next call: window_sent (3) >= max_per_window (3) -> sleep until 1010.
+        # Window: three sends at t=1000, 1001, 1002, now t=1003.
+        # Next call: window full -> sleep until oldest (t=1000) ages out
+        # at t=1010, i.e. 7s. After the sleep only the t=1000 call has
+        # expired; t=1001 and t=1002 are still inside the rolling window.
         clock.sleeps.clear()
         lim.wait_for_capacity()
-        assert lim.window_sent == 0
+        assert lim.window_sent == 2
         assert clock.sleeps == [pytest.approx(7.0)]
 
     def test_window_resets_naturally_when_window_seconds_elapse(self, fast_config, clock):


### PR DESCRIPTION
## Summary

Follow-up to #80 and #81: collapse `lib/acs_rate_limit.py` into a thin
adapter on top of the generic `lib/rate_limit.py` so we have one
sliding-window implementation in the codebase.

PR #80 introduced `SlidingWindowRateLimiter` carved out of the email
job. PR #81 introduced the more general `SlidingWindowLimiter` (true
rolling window, optional `min_interval`, `QuotaExceeded`, injectable
clock) and noted the consolidation as a planned follow-up. This is
that follow-up.

## Approach

**Option chosen: keep `lib/acs_rate_limit.py` as a thin adapter.**

The alternative (delete the module and inline a `SlidingWindowLimiter`
construction in `weekly_email_job.py`) would have churned the email job
without a clear win — the ACS-specific defaults (`acs_default_config()`)
and the `wait_for_capacity` / `record_send` vocabulary used inside the
digest loop are still useful at the call site. Keeping the adapter:

- Lets `weekly_email_job.py` stay byte-identical (no caller changes).
- Preserves `acs_default_config()` as the single place documenting the
  20% headroom we leave for transactional sends from the web tier.
- Removes ~70 lines of duplicated sliding-window logic.

Net: `lib/acs_rate_limit.py` shrinks from 135 lines of real logic to a
~50-line shim that delegates `wait_for_capacity` / `record_send` /
`window_sent` straight through to a single `SlidingWindowLimiter`
configured with `max_calls=max_per_window`,
`window_seconds=window_seconds`, `min_interval_seconds=min_interval_seconds`.

## ACS quota semantics — preserved (and slightly tightened)

Production config is unchanged:

- `min_interval_seconds = 0.75` → ≤80 sends/min via inter-send pacing.
- `max_per_window = 800`, `window_seconds = 3600` → ≤800 sends/hr.

The generic limiter is a **true rolling window** rather than the
fixed-window-with-reset that the ACS module previously implemented.
This is strictly more conservative: at every point in time the rolling
window enforces a tighter or equal bound than the fixed window did
(the fixed window allows bursts across the boundary; the rolling window
does not). The 80/min + 800/hr ceilings still hold.

## Test impact

One assertion in `test_exhausting_window_sleeps_until_window_resets`
was over-specific to the old fixed-window implementation: it expected
`window_sent == 0` after the post-quota sleep, on the assumption that
hitting the cap "resets" the counter. Under the rolling window only the
specific calls that have aged past `window_seconds` are evicted, so
two calls remain in the window after the sleep. The user-observable
behaviour the test was guarding — *the limiter sleeps exactly until
the oldest call ages out (7s)* — is unchanged and still asserted.

Updated assertion:

```python
# Before:
assert lim.window_sent == 0
assert clock.sleeps == [pytest.approx(7.0)]

# After:
assert lim.window_sent == 2
assert clock.sleeps == [pytest.approx(7.0)]
```

All other ACS limiter tests (min-interval pacing, failed-send accounting,
zero-min-interval edge case, window-resets-naturally) pass unchanged
against the adapter. The generic `tests/test_rate_limit.py` suite was
not touched.

## Verification

- `pytest` from the worktree: **334 passed** (no delta from baseline).
- Manual review of `weekly_email_job.py` call sites: constructor
  signature, `wait_for_capacity()`, `record_send()`, and `logger=`
  kwarg all unchanged.
- `code-review` sub-agent reviewed the diff and found no issues.

## Files

- `lib/acs_rate_limit.py` — rewritten as a thin adapter (-49 lines net).
- `lib/rate_limit.py` — docstring updated to reflect that the
  adapter shim now exists (no logic change).
- `tests/test_acs_rate_limit.py` — one assertion updated (see above).
