### PR TITLE
perf(sitemap): explicit XML escape + lock 1h Cache-Control (M11+M12)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1562,10 +1562,11 @@ def _render_sitemap_xml(base_url: str, release_rows) -> str:
     """Render the sitemap XML body for the static pages plus per-release URLs.
 
     ``release_rows`` is any iterable of objects with ``release_item_id`` and
-    ``last_modified`` attributes (e.g. SQLAlchemy rows or test stubs). All
-    interpolated values are XML-escaped — today ``release_item_id`` is a
-    Fabric API GUID with no XML-special characters, so this is
-    defense-in-depth, not a bug fix.
+    ``last_modified`` attributes (e.g. SQLAlchemy rows or test stubs). Each
+    interpolated component (``base_url``, ``release_item_id``, ``lastmod``)
+    is XML-escaped individually — today ``release_item_id`` is a Fabric API
+    GUID with no XML-special characters, so this is defense-in-depth, not a
+    bug fix.
     """
     parts = []
     for p in _STATIC_SITEMAP_PAGES:
@@ -1582,7 +1583,7 @@ def _render_sitemap_xml(base_url: str, release_rows) -> str:
             lastmod = f"\n    <lastmod>{escape(r.last_modified.strftime('%Y-%m-%d'))}</lastmod>"
         parts.append(
             "  <url>\n"
-            f"    <loc>{escape(f'{base_url}/release/{r.release_item_id}')}</loc>{lastmod}\n"
+            f"    <loc>{escape(base_url)}/release/{escape(r.release_item_id)}</loc>{lastmod}\n"
             "    <changefreq>weekly</changefreq>\n"
             "    <priority>0.8</priority>\n"
             "  </url>\n"

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -6,10 +6,12 @@ Importing ``server`` requires ``CURRENT_ENVIRONMENT=development`` (which
 
 from datetime import date
 from types import SimpleNamespace
+from unittest.mock import patch
 import xml.etree.ElementTree as ET
 
 import pytest
 
+import server as server_module
 from server import _render_sitemap_xml, _STATIC_SITEMAP_PAGES
 
 
@@ -89,3 +91,49 @@ class TestRenderSitemapXml:
             assert url.find("sm:loc", ns) is not None
             assert url.find("sm:changefreq", ns) is not None
             assert url.find("sm:priority", ns) is not None
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests for /sitemap.xml — M11 (escape) + M12 (Cache-Control TTL)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    server_module.app.config.update(TESTING=True)
+    with server_module.app.test_client() as c:
+        yield c
+
+
+def test_sitemap_route_sets_one_hour_cache_control(client):
+    """M12: /sitemap.xml advertises a 1-hour TTL so Front Door + bots cache."""
+    rows = [SimpleNamespace(release_item_id="guid-1", last_modified=date(2026, 4, 22))]
+    with patch.object(server_module, "get_engine", return_value=object()), \
+         patch.object(server_module, "get_active_releases_for_sitemap", return_value=rows):
+        resp = client.get("/sitemap.xml")
+
+    assert resp.status_code == 200
+    cache_control = resp.headers.get("Cache-Control", "")
+    assert "public" in cache_control
+    assert "max-age=3600" in cache_control
+
+
+def test_sitemap_route_escapes_release_item_id(client):
+    """M11: defense-in-depth — XML-special chars in IDs round-trip safely."""
+    evil_id = 'a&b<c>d"e'
+    rows = [SimpleNamespace(release_item_id=evil_id, last_modified=date(2026, 4, 22))]
+    with patch.object(server_module, "get_engine", return_value=object()), \
+         patch.object(server_module, "get_active_releases_for_sitemap", return_value=rows):
+        resp = client.get("/sitemap.xml")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Body must parse as XML and contain the evil ID after parsing.
+    root = ET.fromstring(body)
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    locs = [el.text for el in root.findall(".//sm:loc", ns)]
+    assert any(loc and loc.endswith(f"/release/{evil_id}") for loc in locs)
+
+    # Raw bytes must be escaped — no unescaped <c> or & sequence.
+    assert "<c>" not in body


### PR DESCRIPTION
## Summary

Implements **M11 + M12** from the code-quality review for `/sitemap.xml`.

### M11 — explicit XML escape on `release_item_id`
`_render_sitemap_xml` previously wrapped the entire URL f-string in `escape(...)`. That's functionally equivalent (URL characters never need XML escaping), but it drifted from the surrounding convention where each interpolated component is escaped individually. Refactored to:

```python
f"    <loc>{escape(base_url)}/release/{escape(r.release_item_id)}</loc>{lastmod}\n"
```

Today `release_item_id` is a Fabric API GUID with no XML-special characters, so this is **defense-in-depth, not a bug fix** — but it makes the intent explicit and matches the rest of the renderer.

### M12 — lock the 1-hour `Cache-Control` for `/sitemap.xml`
The route already inherits `Cache-Control: public, max-age=3600, stale-while-revalidate=600, must-revalidate` from the shared `_make_cached_response` helper (`_FRONT_END_TTL = 3600`), which aligns with the hourly refresh cadence. No code change needed here — instead, added a route-level regression test so a future TTL change in the shared helper can't silently downgrade the sitemap caching contract.

## Tests

Added two route-level tests in `tests/test_sitemap.py` using the Flask test client:

- `test_sitemap_route_sets_one_hour_cache_control` — asserts `Cache-Control` contains `public` and `max-age=3600`.
- `test_sitemap_route_escapes_release_item_id` — feeds an evil ID (`a&b<c>d"e`) through the route, confirms the body parses as XML and the raw `<c>` / unescaped `&` sequence is not present.

Existing helper-level escape tests still cover `_render_sitemap_xml` directly.

```
pytest: 334 → 336 (all passing)
```

## Risk

Very low. M11 is a no-op for the current data (GUIDs only); M12 is pure test coverage on top of the existing 1-hour TTL.
