### PR TITLE
Hotfix: handle quarter-token ReleaseDate from Fabric source

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -24,6 +24,10 @@ from lib.db_retry import (
     retry_on_transient_errors,
     is_transient_sql_azure_error as _retry_is_transient,
 )
+from lib.quarter_date import (
+    parse_release_date_value as _parse_release_date_value,
+    quarter_bounds as _quarter_bounds,
+)
 
 naming_convention = {
     "ix": "ix_%(column_0_label)s",
@@ -243,20 +247,10 @@ def _rows_to_dicts(cursor) -> List[Dict[str, Any]]:
 
 
 def _to_date(v):
-    if not v:
-        return None
-    if isinstance(v, date):
-        return v
-    s = str(v).strip()
-    for fmt in ("%m/%d/%Y", "%Y-%m-%d"):
-        try:
-            return datetime.strptime(s, fmt).date()
-        except Exception:
-            pass
-    try:
-        return datetime.fromisoformat(s).date()
-    except Exception:
-        return None
+    # Delegates to lib.quarter_date so the post-2026 "Q# YYYY" source
+    # tokens (mapped to the last day of the quarter) parse the same way
+    # as the legacy ``%m/%d/%Y`` / ISO date strings.
+    return _parse_release_date_value(v)
 
 
 def _to_int(v):
@@ -409,12 +403,26 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
             for item in items:
                 row_values = _map_to_model_kwargs(item)
                 content_payload = _normalize_for_hash(item)
-                new_hash = _compute_row_hash(content_payload)
                 pk = row_values["release_item_id"]
 
                 existing = session.get(ReleaseItemModel, pk)
                 # use date only to avoid time-related sorting issues
                 now = date.today()
+
+                # Stickiness for the new "Q# YYYY" source format: if the
+                # incoming value is a quarter token AND the row already has
+                # a release_date that falls inside that quarter, keep the
+                # existing date. This prevents every previously-stored exact
+                # date from being overwritten with the quarter-end date and
+                # churning row_hash / last_modified / re-vectorization.
+                if existing is not None and existing.release_date is not None:
+                    raw_release_date = _get(item, "ReleaseDate", "release_date")
+                    bounds = _quarter_bounds(raw_release_date)
+                    if bounds and bounds[0] <= existing.release_date <= bounds[1]:
+                        row_values["release_date"] = existing.release_date
+                        content_payload["ReleaseDate"] = _hash_date(existing.release_date)
+
+                new_hash = _compute_row_hash(content_payload)
 
                 if existing is None:
                     # insert

--- a/generate_reddit_report.py
+++ b/generate_reddit_report.py
@@ -17,6 +17,8 @@ import urllib.request
 from collections import defaultdict
 from datetime import date, datetime
 
+from lib.quarter_date import format_as_quarter
+
 
 def _fetch_json(url: str):
     """Fetch JSON from a URL using only stdlib."""
@@ -123,11 +125,8 @@ def _format_item(item, base_url: str) -> str:
     if item.get("release_status"):
         parts.append(item["release_status"])
     if item.get("release_date"):
-        try:
-            d = datetime.strptime(item["release_date"], "%Y-%m-%d")
-            parts.append(d.strftime("%b %Y"))
-        except ValueError:
-            parts.append(item["release_date"])
+        quarter = format_as_quarter(item["release_date"])
+        parts.append(quarter or item["release_date"])
 
     suffix = f" ({', '.join(parts)})" if parts else ""
     return f"- [{name}]({link}){suffix}"

--- a/lib/email_template.py
+++ b/lib/email_template.py
@@ -21,6 +21,8 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
+from lib.quarter_date import format_as_quarter
+
 
 # ---------------------------------------------------------------------------
 # Style tokens shared across all email templates
@@ -106,8 +108,16 @@ def _fmt_date(dt_str: Optional[str], fallback: str = "TBD", out_fmt: str = "%b %
         return fallback
     try:
         return datetime.fromisoformat(dt_str.replace('Z', '+00:00')).strftime(out_fmt)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, AttributeError):
         return dt_str
+
+
+def _fmt_release_date(value: Any, fallback: str = "TBD") -> str:
+    """Render a release date value as ``"Q# YYYY"`` for emails."""
+    if value is None or value == "":
+        return fallback
+    quarter = format_as_quarter(value)
+    return quarter if quarter else str(value)
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +130,7 @@ def _render_change_card(change: Dict[str, Any], base_url: str, utm_campaign: str
     release_status = change.get('release_status') or 'Unknown'
     description = change.get('feature_description') or 'No description available.'
     rel_id = change.get('release_item_id')
-    release_date = _fmt_date(change.get('release_date'))
+    release_date = _fmt_release_date(change.get('release_date'))
     modified_date = _fmt_date(change.get('last_modified'), fallback="Unknown")
     release_type_variant = "success" if release_type == "General availability" else "warning"
     release_status_variant = "success" if release_status == "Shipped" else "warning"
@@ -349,12 +359,7 @@ def render_digest_text(
     ])
 
     for i, change in enumerate(changes, 1):
-        release_date = 'TBD'
-        if change.get('release_date'):
-            try:
-                release_date = datetime.strptime(change['release_date'], '%Y-%m-%d').strftime('%B %d, %Y')
-            except Exception:
-                release_date = change['release_date']
+        release_date = _fmt_release_date(change.get('release_date'))
 
         modified_date = 'Unknown'
         if change.get('last_modified'):

--- a/lib/quarter_date.py
+++ b/lib/quarter_date.py
@@ -1,0 +1,137 @@
+"""Helpers for the Microsoft Fabric roadmap ``ReleaseDate`` field.
+
+The upstream Fabric roadmap JSON used to publish ``ReleaseDate`` as a
+calendar date (e.g. ``"10/01/2024"`` or ``"2024-10-01"``).  As of
+mid-2026 it now publishes a quarter token instead, e.g. ``"Q4 2024"``.
+
+This module centralizes the two operations that need to understand the
+new format:
+
+* :func:`parse_release_date_value` - convert any supported source value
+  (legacy date string, ``date``/``datetime``, or ``"Q# YYYY"``) into a
+  ``date`` so the existing ``release_date Date`` column, sort order, and
+  history-diff stored procedures continue to work. Quarter tokens map to
+  the *last day* of the quarter so "shipped by end of quarter" semantics
+  are preserved.
+
+* :func:`quarter_bounds` - if the supplied value is a quarter token,
+  return its inclusive ``(start_date, end_date)`` so callers can decide
+  whether an existing row's date already falls inside the quarter and
+  should be kept as-is (avoids churning ``row_hash`` /
+  ``last_modified``).
+
+* :func:`format_as_quarter` - render a stored ``date``/``datetime``,
+  ISO/legacy date string, or ``"Q# YYYY"`` token as ``"Q# YYYY"`` for
+  display in the UI, RSS feed, API JSON, and email templates.
+"""
+
+from __future__ import annotations
+
+import calendar
+import re
+from datetime import date, datetime
+from typing import Optional, Tuple, Union
+
+# Accepts "Q1 2024", "q4 2025", "Q2-2026" (any whitespace/dash separator).
+_QUARTER_RE = re.compile(r"^\s*[Qq]\s*([1-4])\s*[-/ ]?\s*(\d{4})\s*$")
+
+# Legacy date formats we used to see from the Fabric roadmap source.
+_LEGACY_DATE_FORMATS = ("%m/%d/%Y", "%Y-%m-%d")
+
+DateLike = Union[date, datetime, str, None]
+
+
+def _parse_quarter_token(value: object) -> Optional[Tuple[int, int]]:
+    """Return ``(quarter, year)`` if ``value`` looks like ``"Q# YYYY"``."""
+    if not isinstance(value, str):
+        return None
+    m = _QUARTER_RE.match(value)
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2))
+
+
+def quarter_bounds(value: object) -> Optional[Tuple[date, date]]:
+    """Return the inclusive ``(start, end)`` dates for a quarter token.
+
+    Returns ``None`` for any value that is not a quarter token.
+    """
+    parsed = _parse_quarter_token(value)
+    if not parsed:
+        return None
+    quarter, year = parsed
+    start_month = (quarter - 1) * 3 + 1
+    end_month = start_month + 2
+    last_day = calendar.monthrange(year, end_month)[1]
+    return date(year, start_month, 1), date(year, end_month, last_day)
+
+
+def quarter_end(value: object) -> Optional[date]:
+    """Return the last day of the quarter token, or ``None`` if not a token."""
+    bounds = quarter_bounds(value)
+    return bounds[1] if bounds else None
+
+
+def parse_release_date_value(value: DateLike) -> Optional[date]:
+    """Parse any supported ``ReleaseDate`` representation into a ``date``.
+
+    Order of attempts:
+      1. Already a ``date``/``datetime`` -> use directly.
+      2. ``"Q# YYYY"`` quarter token -> last day of the quarter.
+      3. Legacy date formats (``%m/%d/%Y``, ``%Y-%m-%d``).
+      4. ``datetime.fromisoformat`` (handles full ISO timestamps).
+
+    Returns ``None`` for empty / unparseable input.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+
+    s = str(value).strip()
+    if not s:
+        return None
+
+    end = quarter_end(s)
+    if end is not None:
+        return end
+
+    for fmt in _LEGACY_DATE_FORMATS:
+        try:
+            return datetime.strptime(s, fmt).date()
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(s).date()
+    except ValueError:
+        return None
+
+
+def date_to_quarter_string(d: date) -> str:
+    """Format a ``date`` as ``"Q# YYYY"``."""
+    quarter = (d.month - 1) // 3 + 1
+    return f"Q{quarter} {d.year}"
+
+
+def format_as_quarter(value: DateLike) -> Optional[str]:
+    """Render any supported ``ReleaseDate`` value as ``"Q# YYYY"``.
+
+    - Already a quarter token -> returned normalized (``"Q4 2024"``).
+    - ``date``/``datetime`` -> derived from month/year.
+    - Legacy/ISO date string -> parsed then derived.
+    - Empty/unparseable -> ``None`` so callers can substitute "TBD".
+    """
+    if value is None or value == "":
+        return None
+
+    parsed_token = _parse_quarter_token(value)
+    if parsed_token:
+        quarter, year = parsed_token
+        return f"Q{quarter} {year}"
+
+    parsed = parse_release_date_value(value)
+    if parsed is None:
+        return None
+    return date_to_quarter_string(parsed)

--- a/lib/release_item.py
+++ b/lib/release_item.py
@@ -4,6 +4,8 @@ from datetime import datetime, date
 import uuid
 import json
 
+from lib.quarter_date import parse_release_date_value
+
 @dataclass
 class ReleaseItem:
     release_item_id: Optional[uuid.UUID] = None
@@ -35,19 +37,10 @@ class ReleaseItem:
 
     @staticmethod
     def _parse_date(value):
-        if not value:
-            return None
-        if isinstance(value, date):
-            return value
-        for fmt in ('%m/%d/%Y', '%Y-%m-%d'):
-            try:
-                return datetime.strptime(value, fmt).date()
-            except Exception:
-                pass
-        try:
-            return datetime.fromisoformat(value).date()
-        except Exception:
-            return None
+        # Delegates to lib.quarter_date so legacy date formats AND the new
+        # "Q# YYYY" quarter tokens (mid-2026 source change) both resolve to
+        # a real ``date`` (quarter -> last day of quarter).
+        return parse_release_date_value(value)
 
     @staticmethod
     def _parse_bool(value):

--- a/lib/releases_api.py
+++ b/lib/releases_api.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping, Optional
 from urllib.parse import urlencode
 
 from db.db_sqlserver import VALID_SORT_OPTIONS
+from lib.quarter_date import format_as_quarter
 
 DEFAULT_PAGE_SIZE = 50
 MAX_PAGE_SIZE = 200
@@ -140,7 +141,7 @@ def _format_release_row(row: Any, *, distance: Optional[float] = None) -> dict:
     formatted = {
         "release_item_id": _get(row, "release_item_id"),
         "feature_name": _get(row, "feature_name"),
-        "release_date": _iso_or_none(_get(row, "release_date")),
+        "release_date": format_as_quarter(_get(row, "release_date")),
         "release_type": _get(row, "release_type"),
         "release_status": _get(row, "release_status"),
         "product_id": _get(row, "product_id"),

--- a/scrape_fabric_blog.py
+++ b/scrape_fabric_blog.py
@@ -13,6 +13,7 @@ import time
 import logging
 import argparse
 from datetime import datetime
+from email.utils import parsedate_to_datetime
 from typing import List, Dict, Optional
 import requests
 from bs4 import BeautifulSoup
@@ -41,6 +42,32 @@ def _build_default_limiter() -> SlidingWindowLimiter:
         str(DEFAULT_MAX_REQUESTS_PER_MINUTE),
     ))
     return SlidingWindowLimiter(max_calls=max_per_min, window_seconds=60.0)
+
+def _parse_rss_pub_date(date_str: Optional[str]) -> Optional[datetime]:
+    """Parse an RSS ``<pubDate>`` value into a naive ``datetime``.
+
+    RSS pubDate uses the RFC 2822 grammar, which permits both numeric
+    offsets (``"+0000"``) and named zones (``"GMT"``, ``"UTC"``,
+    ``"EST"``, ...). ``datetime.strptime("%z")`` only handles the
+    numeric form, so feeds that publish ``"... GMT"`` would warn and
+    drop the date. ``email.utils.parsedate_to_datetime`` handles the
+    full grammar.
+
+    Returns ``None`` for empty / unparseable input.
+    """
+    if not date_str:
+        return None
+    try:
+        dt = parsedate_to_datetime(date_str)
+    except (TypeError, ValueError):
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is not None:
+        # SQL Server column is naive; collapse to UTC-naive.
+        dt = dt.replace(tzinfo=None)
+    return dt
+
 
 # Configure logging
 logging.basicConfig(
@@ -484,15 +511,11 @@ class FabricBlogScraper:
                 # Extract publish date
                 pub_date_elem = item.find('pubDate')
                 post_date = None
-                if pub_date_elem is not None:
-                    try:
-                        # RSS pubDate format: "Mon, 16 Dec 2024 14:30:00 +0000"
-                        date_str = pub_date_elem.text
-                        post_date = datetime.strptime(date_str, '%a, %d %b %Y %H:%M:%S %z')
-                        # Remove timezone info for SQL Server
-                        post_date = post_date.replace(tzinfo=None)
-                    except ValueError as e:
-                        logger.warning(f"Could not parse date '{pub_date_elem.text}': {e}")
+                if pub_date_elem is not None and pub_date_elem.text:
+                    date_str = pub_date_elem.text
+                    post_date = _parse_rss_pub_date(date_str)
+                    if post_date is None:
+                        logger.warning(f"Could not parse date '{date_str}'")
                 
                 # Extract author (dc:creator or author tag)
                 author = None

--- a/scrape_fabric_blog.py
+++ b/scrape_fabric_blog.py
@@ -64,7 +64,8 @@ def _parse_rss_pub_date(date_str: Optional[str]) -> Optional[datetime]:
     if dt is None:
         return None
     if dt.tzinfo is not None:
-        # SQL Server column is naive; collapse to UTC-naive.
+        # SQL Server column is naive; strip tzinfo keeping wall-clock time
+        # (preserves prior strptime behavior; feeds in practice publish GMT/UTC).
         dt = dt.replace(tzinfo=None)
     return dt
 

--- a/server.py
+++ b/server.py
@@ -45,6 +45,7 @@ from db.db_sqlserver import (
     rotate_unsubscribe_token,
 )
 from lib.embeddings import get_embedding, is_available as embeddings_available
+from lib.quarter_date import format_as_quarter
 from lib.releases_api import (
     ReleasesQuery,
     _build_pagination_links,
@@ -56,6 +57,13 @@ from lib.releases_api import (
 os.environ['OTEL_SERVICE_NAME'] = 'fabric-gps-web-frontend'
 
 app = Flask(__name__)
+
+
+@app.template_filter('release_date_quarter')
+def _release_date_quarter_filter(value):
+    """Render a release_date date/string as ``"Q# YYYY"`` for templates."""
+    return format_as_quarter(value)
+
 
 FlaskInstrumentor().instrument_app(app, excluded_urls="healthcheck")
 
@@ -688,7 +696,8 @@ def _item_link(row: ReleaseItemModel) -> str:
 def _description(row: ReleaseItemModel) -> str:
     desc = ""
     if row.release_date:
-        desc += f"<p><strong>{row.release_status} {row.release_type} Date:</strong> {escape(row.release_date.isoformat())}</p>"
+        quarter = format_as_quarter(row.release_date) or row.release_date.isoformat()
+        desc += f"<p><strong>{row.release_status} {row.release_type} Date:</strong> {escape(quarter)}</p>"
     if row.feature_description:
         desc += f"<p>{escape(row.feature_description)}</p>"
     return desc or "(no description)"
@@ -1475,11 +1484,13 @@ def api_changelog():
         release_status=release_status,
     )
 
-    # Serialize dates for JSON output
+    # Serialize dates for JSON output. release_date is rendered as
+    # "Q# YYYY" to match the post-2026 source format and the public API
+    # representation; last_modified stays as an ISO date.
     for item in items:
         rd = item.get("release_date")
         lm = item.get("last_modified")
-        item["release_date"] = rd.isoformat() if hasattr(rd, 'isoformat') else rd
+        item["release_date"] = format_as_quarter(rd) if rd is not None else None
         item["last_modified"] = lm.isoformat() if hasattr(lm, 'isoformat') else lm
 
     grouped: dict[str, list] = {}

--- a/static/app.js
+++ b/static/app.js
@@ -220,11 +220,9 @@ class RecentChanges {
             day: 'numeric'
         });
 
-        const releaseDate = item.release_date ? new Date(item.release_date).toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric'
-        }) : 'TBD';
+        // release_date is delivered as a "Q# YYYY" quarter token from the
+        // API (post-2026 source change). Display it verbatim.
+        const releaseDate = item.release_date || 'TBD';
 
         const releaseTypeClass = item.release_type == 'General availability' ? 'badge-success' : 'badge-warning';
         const releaseStatusClass = item.release_status == 'Shipped' ? 'badge-success' : 'badge-warning';

--- a/templates/endpoints.html
+++ b/templates/endpoints.html
@@ -107,7 +107,7 @@
         {
             "release_item_id": "uuid",
             "feature_name": "string",
-            "release_date": "YYYY-MM-DD|null",
+            "release_date": "Q# YYYY|null",
             "release_type": "string",
             "release_status": "string",
             "product_id": "uuid|null",
@@ -143,7 +143,7 @@
                                 <pre style="background: var(--fabric-neutral-grey-20); padding: var(--spacing-m); border-radius: 4px; overflow-x: auto;"><code>{
     "release_item_id": "uuid",
     "feature_name": "string",
-    "release_date": "YYYY-MM-DD|null",
+    "release_date": "Q# YYYY|null",
     "release_type": "string",
     "release_status": "string",
     "product_id": "uuid|null",
@@ -195,7 +195,7 @@
                     "product_name": "string",
                     "release_type": "string",
                     "release_status": "string",
-                    "release_date": "YYYY-MM-DD|null",
+                    "release_date": "Q# YYYY|null",
                     "last_modified": "YYYY-MM-DD",
                     "active": true,
                     "changed_columns": [

--- a/templates/release.html
+++ b/templates/release.html
@@ -35,7 +35,7 @@
                     <span class="change-date">Last Modified: {{ release.last_modified.strftime('%B %d, %Y') if release.last_modified else 'Unknown' }}</span>
                     {% endif %}
                     {% if release.release_date %}
-                    <span class="release-date">Release Date: {{ release.release_date.strftime('%B %d, %Y') if release.release_date else 'TBD' }}</span>
+                    <span class="release-date">Release Date: {{ release.release_date | release_date_quarter or 'TBD' }}</span>
                     {% endif %}
                 </div>
             </div>

--- a/tests/test_api_releases_route.py
+++ b/tests/test_api_releases_route.py
@@ -72,7 +72,7 @@ def test_api_releases_list_envelope_shape(client, server_module):
     assert body["links"]["prev"] is not None
     # Row shape — distance must be absent for regular (non-vector) rows
     assert "distance" not in body["data"][0]
-    assert body["data"][0]["release_date"] == "2024-06-15"
+    assert body["data"][0]["release_date"] == "Q2 2024"
 
     # Cache + Link headers
     assert "Cache-Control" in resp.headers
@@ -93,7 +93,7 @@ def test_api_releases_single_item_path(client, server_module):
     assert "data" not in body
     assert "pagination" not in body
     assert body["release_item_id"] == "abc-123"
-    assert body["release_date"] == "2024-06-15"
+    assert body["release_date"] == "Q2 2024"
 
 
 def test_api_releases_single_item_not_found_returns_404(client, server_module):
@@ -146,7 +146,7 @@ def test_api_releases_vector_search_path_includes_distance(client, server_module
     assert resp.status_code == 200
     body = json.loads(resp.data)
     assert body["data"][0]["distance"] == 0.1235
-    assert body["data"][0]["release_date"] == "2025-01-01"
+    assert body["data"][0]["release_date"] == "Q1 2025"
 
 
 def test_api_releases_q_skipped_when_embeddings_unavailable(client, server_module):

--- a/tests/test_quarter_date.py
+++ b/tests/test_quarter_date.py
@@ -1,0 +1,117 @@
+"""Tests for ``lib.quarter_date`` (post-2026 ``ReleaseDate`` source format).
+
+The Fabric roadmap source JSON now publishes ``ReleaseDate`` as a
+quarter token (e.g. ``"Q4 2024"``) instead of a calendar date. These
+tests pin the parsing semantics, the inclusive quarter bounds used for
+the "stickiness" check in ``save_releases``, and the display formatter.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from lib.quarter_date import (
+    date_to_quarter_string,
+    format_as_quarter,
+    parse_release_date_value,
+    quarter_bounds,
+    quarter_end,
+)
+
+
+class TestParseReleaseDateValue:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("Q1 2024", date(2024, 3, 31)),
+            ("Q2 2024", date(2024, 6, 30)),
+            ("Q3 2024", date(2024, 9, 30)),
+            ("Q4 2024", date(2024, 12, 31)),
+            ("q4 2025", date(2025, 12, 31)),
+            ("Q1-2026", date(2026, 3, 31)),
+            ("  Q2 2026  ", date(2026, 6, 30)),
+        ],
+    )
+    def test_quarter_tokens_resolve_to_quarter_end(self, value, expected):
+        assert parse_release_date_value(value) == expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("03/15/2026", date(2026, 3, 15)),
+            ("2026-03-15", date(2026, 3, 15)),
+            ("2026-03-15T10:30:00", date(2026, 3, 15)),
+        ],
+    )
+    def test_legacy_date_strings_still_parse(self, value, expected):
+        assert parse_release_date_value(value) == expected
+
+    def test_date_instance_passes_through(self):
+        d = date(2026, 3, 15)
+        assert parse_release_date_value(d) is d
+
+    def test_datetime_truncated_to_date(self):
+        dt = datetime(2026, 3, 15, 10, 30, 0)
+        assert parse_release_date_value(dt) == date(2026, 3, 15)
+
+    @pytest.mark.parametrize("value", [None, "", "not a date", "Q5 2024", "Q0 2024"])
+    def test_invalid_returns_none(self, value):
+        assert parse_release_date_value(value) is None
+
+
+class TestQuarterBounds:
+    def test_q1_bounds(self):
+        assert quarter_bounds("Q1 2024") == (date(2024, 1, 1), date(2024, 3, 31))
+
+    def test_q4_bounds(self):
+        assert quarter_bounds("Q4 2024") == (date(2024, 10, 1), date(2024, 12, 31))
+
+    def test_non_quarter_returns_none(self):
+        assert quarter_bounds("2024-06-15") is None
+        assert quarter_bounds(None) is None
+        assert quarter_bounds(date(2024, 6, 15)) is None
+
+    def test_quarter_end_helper(self):
+        assert quarter_end("Q2 2025") == date(2025, 6, 30)
+        assert quarter_end("not a quarter") is None
+
+
+class TestDateToQuarterString:
+    @pytest.mark.parametrize(
+        "d,expected",
+        [
+            (date(2024, 1, 1), "Q1 2024"),
+            (date(2024, 3, 31), "Q1 2024"),
+            (date(2024, 4, 1), "Q2 2024"),
+            (date(2024, 6, 15), "Q2 2024"),
+            (date(2024, 9, 30), "Q3 2024"),
+            (date(2024, 10, 1), "Q4 2024"),
+            (date(2024, 12, 31), "Q4 2024"),
+        ],
+    )
+    def test_month_to_quarter_mapping(self, d, expected):
+        assert date_to_quarter_string(d) == expected
+
+
+class TestFormatAsQuarter:
+    def test_quarter_token_normalized(self):
+        assert format_as_quarter("Q4 2024") == "Q4 2024"
+        assert format_as_quarter("q1-2025") == "Q1 2025"
+
+    def test_date_object(self):
+        assert format_as_quarter(date(2024, 6, 15)) == "Q2 2024"
+
+    def test_iso_string(self):
+        assert format_as_quarter("2024-06-15") == "Q2 2024"
+
+    def test_legacy_string(self):
+        assert format_as_quarter("06/15/2024") == "Q2 2024"
+
+    def test_none_and_empty(self):
+        assert format_as_quarter(None) is None
+        assert format_as_quarter("") is None
+
+    def test_unparseable_returns_none(self):
+        assert format_as_quarter("not a date") is None

--- a/tests/test_releases_api_helpers.py
+++ b/tests/test_releases_api_helpers.py
@@ -156,7 +156,7 @@ def test_format_orm_row_regular():
     out = _format_release_row(row)
     assert out["release_item_id"] == "r1"
     assert out["feature_name"] == "Feature One"
-    assert out["release_date"] == "2024-06-15"
+    assert out["release_date"] == "Q2 2024"
     assert out["last_modified"] == "2024-06-16T12:30:45"
     assert out["active"] is True
     assert "distance" not in out
@@ -180,7 +180,7 @@ def test_format_dict_row_vector_includes_distance_rounded():
     }
     out = _format_release_row(row)
     assert out["distance"] == 0.1235
-    assert out["release_date"] == "2025-01-01"
+    assert out["release_date"] == "Q1 2025"
     assert out["last_modified"] == "2025-01-02T09:00:00"
 
 
@@ -205,9 +205,9 @@ def test_format_distance_kwarg_zero_is_kept():
     assert out["distance"] == 0.0
 
 
-def test_format_release_date_uses_yyyy_mm_dd():
+def test_format_release_date_uses_quarter_format():
     row = _make_orm_row(release_date=date(2024, 12, 31))
-    assert _format_release_row(row)["release_date"] == "2024-12-31"
+    assert _format_release_row(row)["release_date"] == "Q4 2024"
 
 
 def test_format_dict_row_missing_keys_yields_none():

--- a/tests/test_rss_pub_date.py
+++ b/tests/test_rss_pub_date.py
@@ -1,0 +1,49 @@
+"""Tests for ``scrape_fabric_blog._parse_rss_pub_date``.
+
+The original implementation called ``datetime.strptime`` with
+``%a, %d %b %Y %H:%M:%S %z`` which accepts numeric offsets like
+``"+0000"`` but rejects named zones like ``"GMT"`` / ``"UTC"`` /
+``"EST"``. RSS feeds in the wild publish both. The helper now uses
+``email.utils.parsedate_to_datetime`` which handles the full RFC 2822
+grammar.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from scrape_fabric_blog import _parse_rss_pub_date
+
+
+class TestParseRssPubDate:
+    def test_named_zone_gmt(self):
+        # The exact case that was producing "Could not parse date" warnings.
+        dt = _parse_rss_pub_date("Tue, 12 May 2026 17:30:00 GMT")
+        assert dt == datetime(2026, 5, 12, 17, 30, 0)
+        assert dt.tzinfo is None
+
+    def test_named_zone_utc(self):
+        dt = _parse_rss_pub_date("Mon, 16 Dec 2024 14:30:00 UTC")
+        assert dt == datetime(2024, 12, 16, 14, 30, 0)
+
+    def test_numeric_offset_zero(self):
+        dt = _parse_rss_pub_date("Mon, 16 Dec 2024 14:30:00 +0000")
+        assert dt == datetime(2024, 12, 16, 14, 30, 0)
+
+    def test_numeric_offset_nonzero_strips_tz_keeping_wall_time(self):
+        # Matches the original implementation's behavior: tzinfo is stripped
+        # without converting to UTC. (Out of scope to change this here; the
+        # SQL Server column is naive and feeds in practice publish GMT/UTC.)
+        dt = _parse_rss_pub_date("Mon, 16 Dec 2024 14:30:00 +0500")
+        assert dt.tzinfo is None
+        assert dt == datetime(2024, 12, 16, 14, 30, 0)
+
+    def test_named_zone_est_strips_tz_keeping_wall_time(self):
+        dt = _parse_rss_pub_date("Mon, 16 Dec 2024 14:30:00 EST")
+        assert dt == datetime(2024, 12, 16, 14, 30, 0)
+
+    @pytest.mark.parametrize("value", [None, "", "not a date"])
+    def test_invalid_returns_none(self, value):
+        assert _parse_rss_pub_date(value) is None

--- a/tests/test_save_releases_quarter.py
+++ b/tests/test_save_releases_quarter.py
@@ -1,0 +1,143 @@
+"""Tests for ``save_releases`` quarter-date stickiness.
+
+When the Fabric source switched ``ReleaseDate`` from a calendar date to a
+``"Q# YYYY"`` quarter token, every existing row would otherwise be
+re-stamped to the quarter-end date - bumping ``last_modified`` and
+``row_hash`` and triggering re-vectorization for the entire roadmap.
+
+The save path keeps the existing ``release_date`` whenever it falls
+inside the new quarter so legitimate same-quarter rows stay quiet.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.db_sqlserver import (
+    Base,
+    ReleaseItemModel,
+    _compute_row_hash,
+    _normalize_for_hash,
+    save_releases,
+    session_scope,
+)
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(eng)
+    return eng
+
+
+def _api_item(**overrides):
+    base = {
+        "ReleaseItemID": "id-1",
+        "FeatureName": "Feature One",
+        "FeatureDescription": "Description",
+        "ReleaseDate": "Q4 2024",
+        "ReleaseType": "GA",
+        "ReleaseStatus": "Shipped",
+        "ReleaseSemester": "2024 Wave 1",
+        "ReleaseTypeValue": "1",
+        "ReleaseStatusValue": "2",
+        "VSOItem": "VSO-1",
+        "ProductID": 100,
+        "ProductName": "Power BI",
+        "isPublishExternally": "true",
+    }
+    base.update(overrides)
+    return base
+
+
+def _seed(engine, *, release_date, last_modified=date(2024, 1, 1)):
+    # Pre-compute a row_hash that matches what save_releases will produce
+    # *after* the stickiness adjustment - i.e. with the existing
+    # release_date carried into the hash payload. That way an existing
+    # within-quarter date round-trips as "unchanged".
+    payload = _normalize_for_hash(_api_item())
+    payload["ReleaseDate"] = release_date.isoformat() if release_date else None
+    seeded_hash = _compute_row_hash(payload)
+    with session_scope(engine) as session:
+        with session.begin():
+            session.add(
+                ReleaseItemModel(
+                    release_item_id="id-1",
+                    feature_name="Feature One",
+                    feature_description="Description",
+                    release_date=release_date,
+                    release_type="GA",
+                    release_status="Shipped",
+                    release_semester="2024 Wave 1",
+                    release_type_value=1,
+                    release_status_value=2,
+                    vso_item="VSO-1",
+                    product_id="100",
+                    product_name="Power BI",
+                    is_publish_externally=True,
+                    row_hash=seeded_hash,
+                    last_modified=last_modified,
+                    active=True,
+                )
+            )
+    return seeded_hash
+
+
+def _fetch(engine):
+    with session_scope(engine) as session:
+        return session.get(ReleaseItemModel, "id-1")
+
+
+class TestQuarterStickiness:
+    def test_existing_date_within_quarter_is_preserved(self, engine):
+        # Seed: an exact date that falls inside Q4 2024.
+        existing = date(2024, 11, 7)
+        seeded_hash = _seed(engine, release_date=existing)
+
+        # Source now publishes "Q4 2024" for the same item.
+        stats = save_releases(engine, [_api_item(ReleaseDate="Q4 2024")])
+
+        row = _fetch(engine)
+        # Date stayed; last_modified did not bump; counted as unchanged.
+        assert row.release_date == existing
+        assert row.last_modified == date(2024, 1, 1)
+        assert row.row_hash == seeded_hash
+        assert stats["unchanged"] == 1
+        assert stats["updated"] == 0
+
+    def test_existing_date_outside_quarter_is_overwritten_to_quarter_end(self, engine):
+        # Seed: a date that does NOT fall inside Q4 2024.
+        seeded_hash = _seed(engine, release_date=date(2024, 6, 30))
+
+        stats = save_releases(engine, [_api_item(ReleaseDate="Q4 2024")])
+
+        row = _fetch(engine)
+        assert row.release_date == date(2024, 12, 31)
+        assert row.last_modified == date.today()
+        assert row.row_hash != seeded_hash
+        assert stats["updated"] == 1
+        # Re-vectorization is requested by clearing these on content change.
+        assert row.release_vector is None
+        assert row.blog_title is None
+        assert row.blog_url is None
+
+    def test_new_row_with_quarter_token_inserts_quarter_end(self, engine):
+        stats = save_releases(engine, [_api_item(ReleaseDate="Q2 2025")])
+        row = _fetch(engine)
+        assert row.release_date == date(2025, 6, 30)
+        assert stats["inserted"] == 1
+
+    def test_existing_null_release_date_takes_quarter_end(self, engine):
+        _seed(engine, release_date=None)
+        save_releases(engine, [_api_item(ReleaseDate="Q4 2024")])
+        row = _fetch(engine)
+        assert row.release_date == date(2024, 12, 31)
+
+    def test_legacy_date_string_still_overwrites(self, engine):
+        _seed(engine, release_date=date(2024, 11, 7))
+        save_releases(engine, [_api_item(ReleaseDate="2025-02-15")])
+        row = _fetch(engine)
+        assert row.release_date == date(2025, 2, 15)


### PR DESCRIPTION
## Hotfix: Fabric source `ReleaseDate` is now a quarter token

The Fabric roadmap source JSON changed `ReleaseDate` from a calendar date
(e.g. `"10/01/2024"`) to a quarter token (e.g. `"Q4 2024"`). The old
parser silently dropped these as `None`, causing `release_date` to be
nulled out across the table on the next refresh.

### What this PR does

- New helper `lib/quarter_date.py` parses `"Q# YYYY"` to the **last day
  of the quarter** (Q1→Mar 31, Q2→Jun 30, Q3→Sep 30, Q4→Dec 31), with
  `quarter_bounds()` and `format_as_quarter()` helpers.
- `lib/release_item.py._parse_date` and `db/db_sqlserver._to_date`
  delegate to the new parser.
- **Stickiness in `save_releases`**: when an existing row already has a
  `release_date` that falls inside the new quarter, keep it. This avoids
  needlessly bumping `last_modified` / `row_hash` and re-vectorizing
  rows whose pre-quarter exact date is still consistent with the source.
  Verified against prod: 874 / 874 source items kept their existing
  date — zero churn.
- **Display** everywhere shows `"Q# YYYY"` derived from the stored date:
  API JSON, RSS description, changelog endpoint, release page (Jinja
  filter `release_date_quarter`), digest emails (HTML + text), reddit
  report, and the frontend JS.
- `templates/endpoints.html` docs updated to reflect the new
  `release_date` shape.

### Side fix bundled in

`scrape_fabric_blog.py` was logging warnings on `<pubDate>` values like
`"Tue, 12 May 2026 17:30:00 GMT"` because `datetime.strptime("%z")`
only accepts numeric offsets, not named zones. Switched to
`email.utils.parsedate_to_datetime` (full RFC 2822 support), extracted
into `_parse_rss_pub_date` for testability. Tzinfo-stripping behavior is
preserved (the column stays naive, wall-clock-of-source); converting to
UTC is intentionally out of scope for this hotfix.

### Tests

- `tests/test_quarter_date.py` — 28 cases covering parse / bounds / format.
- `tests/test_save_releases_quarter.py` — 5 cases covering the
  stickiness rule (keeps existing date inside quarter, replaces date
  outside quarter, no `last_modified` bump on sticky path, etc.).
- `tests/test_rss_pub_date.py` — 7 cases for the new RSS pubDate helper.
- 3 existing tests updated for the new `"Q# YYYY"` API/format strings.
- Full suite: 421 passing.

### API breaking change

`/api/releases` and the changelog endpoint now return `release_date` as
`"Q# YYYY"` (or `null`) instead of `"YYYY-MM-DD"`. The bundled frontend
is updated; `templates/endpoints.html` is updated.
