### PR TITLE
Hotfix: preserve raw ReleaseDate so stickiness works on the ReleaseItem path

### DIFF
--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -426,6 +426,18 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
                         row_values["release_date"] = existing.release_date
                         content_payload["ReleaseDate"] = _hash_date(existing.release_date)
 
+                # Stickiness for ``vso_item``: the Fabric source intermittently
+                # drops ``VSOItem`` from the payload for items that previously
+                # had it, then includes it again on the next refresh. Without
+                # stickiness, every flap toggles ``row_hash`` and re-vectorizes
+                # the whole roadmap. If the incoming value is empty/whitespace
+                # and we already have a populated value, keep ours.
+                if existing is not None and existing.vso_item:
+                    incoming_vso = row_values.get("vso_item")
+                    if not (isinstance(incoming_vso, str) and incoming_vso.strip()):
+                        row_values["vso_item"] = existing.vso_item
+                        content_payload["VSOItem"] = existing.vso_item
+
                 new_hash = _compute_row_hash(content_payload)
 
                 if existing is None:

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -311,6 +311,7 @@ class _ReleaseFieldSpec:
     model_attr: str      # snake_case, the ReleaseItemModel attribute name
     hash_transform: Callable[[Any], Any] = field(default=lambda v: v)
     model_transform: Callable[[Any], Any] = field(default=lambda v: v)
+    include_in_hash: bool = True  # set False for fields that should never trigger row_hash churn
 
 
 def _hash_date(v):
@@ -339,7 +340,12 @@ _RELEASE_FIELDS: List[_ReleaseFieldSpec] = [
     _ReleaseFieldSpec("ReleaseType", "release_type"),
     _ReleaseFieldSpec("ReleaseStatus", "release_status"),
     _ReleaseFieldSpec("ReleaseSemester", "release_semester"),
-    _ReleaseFieldSpec("VSOItem", "vso_item"),
+    # ``VSOItem`` is excluded from the row_hash: the Fabric source flaps
+    # it on/off intermittently for the same item, which previously bumped
+    # last_modified and re-vectorized the entire roadmap on every flap.
+    # We still persist whatever the source sends (subject to the
+    # stickiness rule in ``save_releases``) but it can't trigger churn.
+    _ReleaseFieldSpec("VSOItem", "vso_item", include_in_hash=False),
     _ReleaseFieldSpec("ProductName", "product_name"),
 
     # Numeric fields share the same transform on both sides.
@@ -368,6 +374,7 @@ def _normalize_for_hash(item: Any) -> Dict[str, Any]:
     return {
         spec.api_name: spec.hash_transform(_get(item, spec.api_name, spec.model_attr))
         for spec in _RELEASE_FIELDS
+        if spec.include_in_hash
     }
 
 
@@ -428,15 +435,14 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
 
                 # Stickiness for ``vso_item``: the Fabric source intermittently
                 # drops ``VSOItem`` from the payload for items that previously
-                # had it, then includes it again on the next refresh. Without
-                # stickiness, every flap toggles ``row_hash`` and re-vectorizes
-                # the whole roadmap. If the incoming value is empty/whitespace
-                # and we already have a populated value, keep ours.
+                # had it, then includes it again on the next refresh. Even
+                # though VSOItem no longer participates in row_hash (so it
+                # can't churn last_modified by itself), we still want to
+                # preserve the URL so we don't lose useful tracking data.
                 if existing is not None and existing.vso_item:
                     incoming_vso = row_values.get("vso_item")
                     if not (isinstance(incoming_vso, str) and incoming_vso.strip()):
                         row_values["vso_item"] = existing.vso_item
-                        content_payload["VSOItem"] = existing.vso_item
 
                 new_hash = _compute_row_hash(content_payload)
 
@@ -460,6 +466,14 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
 
                     if (existing.row_hash or "") == new_hash:
                         unchanged += 1
+                        # Silently sync ``vso_item`` even when the row is
+                        # otherwise unchanged: VSOItem is excluded from the
+                        # hash, so its updates wouldn't reach this branch
+                        # otherwise. Doesn't bump last_modified / row_hash and
+                        # doesn't trigger re-vectorization.
+                        new_vso = row_values.get("vso_item")
+                        if existing.vso_item != new_vso:
+                            existing.vso_item = new_vso
                     else:
                         # update only when changed
                         for k, v in row_values.items():

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -416,7 +416,11 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
                 # date from being overwritten with the quarter-end date and
                 # churning row_hash / last_modified / re-vectorization.
                 if existing is not None and existing.release_date is not None:
-                    raw_release_date = _get(item, "ReleaseDate", "release_date")
+                    # Look up the *raw* source value so quarter-token detection
+                    # works for both dict items (key ``ReleaseDate``) and
+                    # ``ReleaseItem`` instances (attr ``release_date_raw``,
+                    # since ``release_date`` is already a parsed ``date``).
+                    raw_release_date = _get(item, "ReleaseDate", "release_date_raw")
                     bounds = _quarter_bounds(raw_release_date)
                     if bounds and bounds[0] <= existing.release_date <= bounds[1]:
                         row_values["release_date"] = existing.release_date

--- a/db/db_sqlserver.py
+++ b/db/db_sqlserver.py
@@ -311,7 +311,6 @@ class _ReleaseFieldSpec:
     model_attr: str      # snake_case, the ReleaseItemModel attribute name
     hash_transform: Callable[[Any], Any] = field(default=lambda v: v)
     model_transform: Callable[[Any], Any] = field(default=lambda v: v)
-    include_in_hash: bool = True  # set False for fields that should never trigger row_hash churn
 
 
 def _hash_date(v):
@@ -340,12 +339,7 @@ _RELEASE_FIELDS: List[_ReleaseFieldSpec] = [
     _ReleaseFieldSpec("ReleaseType", "release_type"),
     _ReleaseFieldSpec("ReleaseStatus", "release_status"),
     _ReleaseFieldSpec("ReleaseSemester", "release_semester"),
-    # ``VSOItem`` is excluded from the row_hash: the Fabric source flaps
-    # it on/off intermittently for the same item, which previously bumped
-    # last_modified and re-vectorized the entire roadmap on every flap.
-    # We still persist whatever the source sends (subject to the
-    # stickiness rule in ``save_releases``) but it can't trigger churn.
-    _ReleaseFieldSpec("VSOItem", "vso_item", include_in_hash=False),
+    _ReleaseFieldSpec("VSOItem", "vso_item"),
     _ReleaseFieldSpec("ProductName", "product_name"),
 
     # Numeric fields share the same transform on both sides.
@@ -374,7 +368,6 @@ def _normalize_for_hash(item: Any) -> Dict[str, Any]:
     return {
         spec.api_name: spec.hash_transform(_get(item, spec.api_name, spec.model_attr))
         for spec in _RELEASE_FIELDS
-        if spec.include_in_hash
     }
 
 
@@ -435,14 +428,15 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
 
                 # Stickiness for ``vso_item``: the Fabric source intermittently
                 # drops ``VSOItem`` from the payload for items that previously
-                # had it, then includes it again on the next refresh. Even
-                # though VSOItem no longer participates in row_hash (so it
-                # can't churn last_modified by itself), we still want to
-                # preserve the URL so we don't lose useful tracking data.
+                # had it, then includes it again on the next refresh. Without
+                # stickiness, every flap toggles ``row_hash`` and re-vectorizes
+                # the whole roadmap. If the incoming value is empty/whitespace
+                # and we already have a populated value, keep ours.
                 if existing is not None and existing.vso_item:
                     incoming_vso = row_values.get("vso_item")
                     if not (isinstance(incoming_vso, str) and incoming_vso.strip()):
                         row_values["vso_item"] = existing.vso_item
+                        content_payload["VSOItem"] = existing.vso_item
 
                 new_hash = _compute_row_hash(content_payload)
 
@@ -466,14 +460,6 @@ def save_releases(engine, items: Iterable[Any]) -> Dict[str, int]:
 
                     if (existing.row_hash or "") == new_hash:
                         unchanged += 1
-                        # Silently sync ``vso_item`` even when the row is
-                        # otherwise unchanged: VSOItem is excluded from the
-                        # hash, so its updates wouldn't reach this branch
-                        # otherwise. Doesn't bump last_modified / row_hash and
-                        # doesn't trigger re-vectorization.
-                        new_vso = row_values.get("vso_item")
-                        if existing.vso_item != new_vso:
-                            existing.vso_item = new_vso
                     else:
                         # update only when changed
                         for k, v in row_values.items():

--- a/lib/release_item.py
+++ b/lib/release_item.py
@@ -21,6 +21,10 @@ class ReleaseItem:
     product_name: Optional[str] = None
     is_publish_externally: Optional[bool] = None
     feature_description: Optional[str] = None
+    # Preserves the unparsed source ``ReleaseDate`` (e.g. ``"Q4 2024"``) so
+    # downstream code can still detect a quarter token after ``release_date``
+    # has been resolved to a ``date``. Not part of the persisted schema.
+    release_date_raw: Optional[str] = None
 
     @staticmethod
     def _parse_uuid(value):
@@ -80,6 +84,7 @@ class ReleaseItem:
             product_name = d.get('ProductName'),
             is_publish_externally = cls._parse_bool(d.get('isPublishExternally')),
             feature_description = d.get('FeatureDescription'),
+            release_date_raw = d.get('ReleaseDate') if isinstance(d.get('ReleaseDate'), str) else None,
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/tests/test_release_fields.py
+++ b/tests/test_release_fields.py
@@ -88,9 +88,6 @@ class TestReleaseFieldsRegistry:
 class TestNormalizeForHash:
     def test_pascalcase_input(self):
         out = _normalize_for_hash(_API_ITEM)
-        # VSOItem is intentionally excluded from the hash payload — the
-        # source flaps it on/off and we don't want it to churn row_hash.
-        assert "VSOItem" not in out
         assert out == {
             "FeatureName": "Feature X",
             "FeatureDescription": "Feature X description",
@@ -100,21 +97,11 @@ class TestNormalizeForHash:
             "ReleaseSemester": "2026 H1",
             "ReleaseTypeValue": 1,
             "ReleaseStatusValue": 2,
+            "VSOItem": "VSO-9999",
             "ProductID": "12345",
             "ProductName": "Fabric",
             "isPublishExternally": True,
         }
-
-    def test_vsoitem_changes_do_not_change_hash(self):
-        """VSOItem flapping in the source must not bump row_hash."""
-        item_with = {**_API_ITEM, "VSOItem": "VSO-1111"}
-        item_without = {**_API_ITEM}
-        item_without.pop("VSOItem", None)
-        item_blank = {**_API_ITEM, "VSOItem": ""}
-        h_with = _compute_row_hash(_normalize_for_hash(item_with))
-        h_without = _compute_row_hash(_normalize_for_hash(item_without))
-        h_blank = _compute_row_hash(_normalize_for_hash(item_blank))
-        assert h_with == h_without == h_blank
 
     def test_snakecase_input_produces_same_hash(self):
         """Both helpers fall through to ``_get(item, api_name, model_attr)``

--- a/tests/test_release_fields.py
+++ b/tests/test_release_fields.py
@@ -88,6 +88,9 @@ class TestReleaseFieldsRegistry:
 class TestNormalizeForHash:
     def test_pascalcase_input(self):
         out = _normalize_for_hash(_API_ITEM)
+        # VSOItem is intentionally excluded from the hash payload — the
+        # source flaps it on/off and we don't want it to churn row_hash.
+        assert "VSOItem" not in out
         assert out == {
             "FeatureName": "Feature X",
             "FeatureDescription": "Feature X description",
@@ -97,11 +100,21 @@ class TestNormalizeForHash:
             "ReleaseSemester": "2026 H1",
             "ReleaseTypeValue": 1,
             "ReleaseStatusValue": 2,
-            "VSOItem": "VSO-9999",
             "ProductID": "12345",
             "ProductName": "Fabric",
             "isPublishExternally": True,
         }
+
+    def test_vsoitem_changes_do_not_change_hash(self):
+        """VSOItem flapping in the source must not bump row_hash."""
+        item_with = {**_API_ITEM, "VSOItem": "VSO-1111"}
+        item_without = {**_API_ITEM}
+        item_without.pop("VSOItem", None)
+        item_blank = {**_API_ITEM, "VSOItem": ""}
+        h_with = _compute_row_hash(_normalize_for_hash(item_with))
+        h_without = _compute_row_hash(_normalize_for_hash(item_without))
+        h_blank = _compute_row_hash(_normalize_for_hash(item_blank))
+        assert h_with == h_without == h_blank
 
     def test_snakecase_input_produces_same_hash(self):
         """Both helpers fall through to ``_get(item, api_name, model_attr)``

--- a/tests/test_save_releases_quarter.py
+++ b/tests/test_save_releases_quarter.py
@@ -45,7 +45,7 @@ def _api_item(**overrides):
         "ReleaseTypeValue": "1",
         "ReleaseStatusValue": "2",
         "VSOItem": "VSO-1",
-        "ProductID": 100,
+        "ProductID": "00000000-0000-0000-0000-000000000aaa",
         "ProductName": "Power BI",
         "isPublishExternally": "true",
     }
@@ -75,7 +75,7 @@ def _seed(engine, *, release_date, last_modified=date(2024, 1, 1)):
                     release_type_value=1,
                     release_status_value=2,
                     vso_item="VSO-1",
-                    product_id="100",
+                    product_id="00000000-0000-0000-0000-000000000aaa",
                     product_name="Power BI",
                     is_publish_externally=True,
                     row_hash=seeded_hash,
@@ -141,3 +141,89 @@ class TestQuarterStickiness:
         save_releases(engine, [_api_item(ReleaseDate="2025-02-15")])
         row = _fetch(engine)
         assert row.release_date == date(2025, 2, 15)
+
+    def test_releaseitem_dataclass_path_preserves_existing_in_quarter(self, engine):
+        # Regression: production runs items through ReleaseItem.from_dict,
+        # which parses ReleaseDate -> date BEFORE save_releases sees it.
+        # Without preserving the raw source string, stickiness silently
+        # broke and every row got re-stamped to the quarter-end date.
+        from lib.release_item import ReleaseItem
+
+        rid = "00000000-0000-0000-0000-000000000001"
+        existing = date(2024, 11, 7)
+        # Re-seed under a uuid id so ReleaseItem (which parses the id as a
+        # uuid) collides with the existing row.
+        with session_scope(engine) as session:
+            with session.begin():
+                payload = _normalize_for_hash(_api_item(ReleaseItemID=rid))
+                payload["ReleaseDate"] = existing.isoformat()
+                seeded_hash = _compute_row_hash(payload)
+                session.add(
+                    ReleaseItemModel(
+                        release_item_id=rid,
+                        feature_name="Feature One",
+                        feature_description="Description",
+                        release_date=existing,
+                        release_type="GA",
+                        release_status="Shipped",
+                        release_semester="2024 Wave 1",
+                        release_type_value=1,
+                        release_status_value=2,
+                        vso_item="VSO-1",
+                        product_id="00000000-0000-0000-0000-000000000aaa",
+                        product_name="Power BI",
+                        is_publish_externally=True,
+                        row_hash=seeded_hash,
+                        last_modified=date(2024, 1, 1),
+                        active=True,
+                    )
+                )
+
+        items = [ReleaseItem.from_dict(_api_item(ReleaseItemID=rid, ReleaseDate="Q4 2024"))]
+        stats = save_releases(engine, items)
+
+        with session_scope(engine) as session:
+            row = session.get(ReleaseItemModel, rid)
+            assert row.release_date == existing
+            assert row.last_modified == date(2024, 1, 1)
+            assert row.row_hash == seeded_hash
+        assert stats["unchanged"] == 1
+        assert stats["updated"] == 0
+
+    def test_releaseitem_dataclass_path_overwrites_when_outside_quarter(self, engine):
+        from lib.release_item import ReleaseItem
+
+        rid = "00000000-0000-0000-0000-000000000002"
+        with session_scope(engine) as session:
+            with session.begin():
+                payload = _normalize_for_hash(_api_item(ReleaseItemID=rid))
+                payload["ReleaseDate"] = date(2024, 6, 30).isoformat()
+                seeded_hash = _compute_row_hash(payload)
+                session.add(
+                    ReleaseItemModel(
+                        release_item_id=rid,
+                        feature_name="Feature One",
+                        feature_description="Description",
+                        release_date=date(2024, 6, 30),
+                        release_type="GA",
+                        release_status="Shipped",
+                        release_semester="2024 Wave 1",
+                        release_type_value=1,
+                        release_status_value=2,
+                        vso_item="VSO-1",
+                        product_id="00000000-0000-0000-0000-000000000aaa",
+                        product_name="Power BI",
+                        is_publish_externally=True,
+                        row_hash=seeded_hash,
+                        last_modified=date(2024, 1, 1),
+                        active=True,
+                    )
+                )
+
+        items = [ReleaseItem.from_dict(_api_item(ReleaseItemID=rid, ReleaseDate="Q4 2024"))]
+        stats = save_releases(engine, items)
+
+        with session_scope(engine) as session:
+            row = session.get(ReleaseItemModel, rid)
+            assert row.release_date == date(2024, 12, 31)
+        assert stats["updated"] == 1

--- a/tests/test_save_releases_vso_stickiness.py
+++ b/tests/test_save_releases_vso_stickiness.py
@@ -122,22 +122,15 @@ class TestVsoItemStickiness:
         assert row.row_hash == seeded_hash
         assert stats["unchanged"] == 1
 
-    def test_new_vso_silently_overwrites_existing(self, engine):
-        # VSOItem is excluded from the hash, so the row is "unchanged" from
-        # a content-tracking perspective, but we still sync the persisted
-        # value so the column reflects source reality.
-        seeded_hash = _seed(engine, vso_item=_VSO_URL)
+    def test_new_vso_overwrites_existing(self, engine):
+        _seed(engine, vso_item=_VSO_URL)
         new_url = "https://dev.azure.com/powerbi/_workitems/edit/9999999/"
 
         stats = save_releases(engine, [_api_item(VSOItem=new_url)])
 
         row = _fetch(engine)
         assert row.vso_item == new_url
-        # Hash unchanged, last_modified unchanged, counted as unchanged.
-        assert row.row_hash == seeded_hash
-        assert row.last_modified == date(2024, 1, 1)
-        assert stats["unchanged"] == 1
-        assert stats["updated"] == 0
+        assert stats["updated"] == 1
 
     def test_empty_source_inserts_null_for_new_row(self, engine):
         # No existing row; nothing to be sticky about.
@@ -150,15 +143,12 @@ class TestVsoItemStickiness:
         assert stats["inserted"] == 1
 
     def test_empty_existing_takes_new_value(self, engine):
-        seeded_hash = _seed(engine, vso_item=None)
+        _seed(engine, vso_item=None)
         stats = save_releases(engine, [_api_item(VSOItem=_VSO_URL)])
 
         row = _fetch(engine)
-        # Silently synced even though hash didn't change.
         assert row.vso_item == _VSO_URL
-        assert row.row_hash == seeded_hash
-        assert stats["unchanged"] == 1
-        assert stats["updated"] == 0
+        assert stats["updated"] == 1
 
     def test_releaseitem_dataclass_path_preserves_existing_vso(self, engine):
         # Regression: the production code path runs items through

--- a/tests/test_save_releases_vso_stickiness.py
+++ b/tests/test_save_releases_vso_stickiness.py
@@ -122,15 +122,22 @@ class TestVsoItemStickiness:
         assert row.row_hash == seeded_hash
         assert stats["unchanged"] == 1
 
-    def test_new_vso_overwrites_existing(self, engine):
-        _seed(engine, vso_item=_VSO_URL)
+    def test_new_vso_silently_overwrites_existing(self, engine):
+        # VSOItem is excluded from the hash, so the row is "unchanged" from
+        # a content-tracking perspective, but we still sync the persisted
+        # value so the column reflects source reality.
+        seeded_hash = _seed(engine, vso_item=_VSO_URL)
         new_url = "https://dev.azure.com/powerbi/_workitems/edit/9999999/"
 
         stats = save_releases(engine, [_api_item(VSOItem=new_url)])
 
         row = _fetch(engine)
         assert row.vso_item == new_url
-        assert stats["updated"] == 1
+        # Hash unchanged, last_modified unchanged, counted as unchanged.
+        assert row.row_hash == seeded_hash
+        assert row.last_modified == date(2024, 1, 1)
+        assert stats["unchanged"] == 1
+        assert stats["updated"] == 0
 
     def test_empty_source_inserts_null_for_new_row(self, engine):
         # No existing row; nothing to be sticky about.
@@ -143,12 +150,15 @@ class TestVsoItemStickiness:
         assert stats["inserted"] == 1
 
     def test_empty_existing_takes_new_value(self, engine):
-        _seed(engine, vso_item=None)
+        seeded_hash = _seed(engine, vso_item=None)
         stats = save_releases(engine, [_api_item(VSOItem=_VSO_URL)])
 
         row = _fetch(engine)
+        # Silently synced even though hash didn't change.
         assert row.vso_item == _VSO_URL
-        assert stats["updated"] == 1
+        assert row.row_hash == seeded_hash
+        assert stats["unchanged"] == 1
+        assert stats["updated"] == 0
 
     def test_releaseitem_dataclass_path_preserves_existing_vso(self, engine):
         # Regression: the production code path runs items through

--- a/tests/test_save_releases_vso_stickiness.py
+++ b/tests/test_save_releases_vso_stickiness.py
@@ -1,0 +1,169 @@
+"""Tests for ``vso_item`` stickiness in ``save_releases``.
+
+The Fabric source intermittently drops ``VSOItem`` from a row's payload
+and then includes it again on the next refresh. Without stickiness,
+every flap toggles ``row_hash`` / ``last_modified`` and triggers
+re-vectorization of the entire roadmap.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.db_sqlserver import (
+    Base,
+    ReleaseItemModel,
+    _compute_row_hash,
+    _normalize_for_hash,
+    save_releases,
+    session_scope,
+)
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(eng)
+    return eng
+
+
+_VSO_URL = "https://dev.azure.com/powerbi/Release%20Planner/_workitems/edit/1328302/"
+
+
+def _api_item(**overrides):
+    base = {
+        "ReleaseItemID": "00000000-0000-0000-0000-000000000010",
+        "FeatureName": "Notebook integration",
+        "FeatureDescription": "Description",
+        "ReleaseDate": "2024-03-25",
+        "ReleaseType": "Public preview",
+        "ReleaseStatus": "Shipped",
+        "ReleaseSemester": "2023 Wave 2",
+        "ReleaseTypeValue": "578500001",
+        "ReleaseStatusValue": "457530002",
+        "VSOItem": _VSO_URL,
+        "ProductID": "00000000-0000-0000-0000-0000000000aa",
+        "ProductName": "Real-Time Intelligence",
+        "isPublishExternally": "true",
+    }
+    base.update(overrides)
+    return base
+
+
+def _seed(engine, *, vso_item, last_modified=date(2024, 1, 1)):
+    payload = _normalize_for_hash(_api_item(VSOItem=vso_item))
+    seeded_hash = _compute_row_hash(payload)
+    with session_scope(engine) as session:
+        with session.begin():
+            session.add(
+                ReleaseItemModel(
+                    release_item_id="00000000-0000-0000-0000-000000000010",
+                    feature_name="Notebook integration",
+                    feature_description="Description",
+                    release_date=date(2024, 3, 25),
+                    release_type="Public preview",
+                    release_status="Shipped",
+                    release_semester="2023 Wave 2",
+                    release_type_value=578500001,
+                    release_status_value=457530002,
+                    vso_item=vso_item,
+                    product_id="00000000-0000-0000-0000-0000000000aa",
+                    product_name="Real-Time Intelligence",
+                    is_publish_externally=True,
+                    row_hash=seeded_hash,
+                    last_modified=last_modified,
+                    active=True,
+                )
+            )
+    return seeded_hash
+
+
+def _fetch(engine):
+    with session_scope(engine) as session:
+        return session.get(ReleaseItemModel, "00000000-0000-0000-0000-000000000010")
+
+
+class TestVsoItemStickiness:
+    def test_existing_vso_kept_when_source_drops_it(self, engine):
+        seeded_hash = _seed(engine, vso_item=_VSO_URL)
+
+        # Source omits VSOItem entirely (key missing).
+        item = _api_item()
+        del item["VSOItem"]
+        stats = save_releases(engine, [item])
+
+        row = _fetch(engine)
+        assert row.vso_item == _VSO_URL
+        assert row.row_hash == seeded_hash
+        assert row.last_modified == date(2024, 1, 1)
+        assert stats["unchanged"] == 1
+        assert stats["updated"] == 0
+
+    def test_existing_vso_kept_when_source_sends_null(self, engine):
+        seeded_hash = _seed(engine, vso_item=_VSO_URL)
+
+        stats = save_releases(engine, [_api_item(VSOItem=None)])
+
+        row = _fetch(engine)
+        assert row.vso_item == _VSO_URL
+        assert row.row_hash == seeded_hash
+        assert stats["unchanged"] == 1
+
+    def test_existing_vso_kept_when_source_sends_blank(self, engine):
+        seeded_hash = _seed(engine, vso_item=_VSO_URL)
+
+        stats = save_releases(engine, [_api_item(VSOItem="   ")])
+
+        row = _fetch(engine)
+        assert row.vso_item == _VSO_URL
+        assert row.row_hash == seeded_hash
+        assert stats["unchanged"] == 1
+
+    def test_new_vso_overwrites_existing(self, engine):
+        _seed(engine, vso_item=_VSO_URL)
+        new_url = "https://dev.azure.com/powerbi/_workitems/edit/9999999/"
+
+        stats = save_releases(engine, [_api_item(VSOItem=new_url)])
+
+        row = _fetch(engine)
+        assert row.vso_item == new_url
+        assert stats["updated"] == 1
+
+    def test_empty_source_inserts_null_for_new_row(self, engine):
+        # No existing row; nothing to be sticky about.
+        item = _api_item()
+        del item["VSOItem"]
+        stats = save_releases(engine, [item])
+
+        row = _fetch(engine)
+        assert row.vso_item is None
+        assert stats["inserted"] == 1
+
+    def test_empty_existing_takes_new_value(self, engine):
+        _seed(engine, vso_item=None)
+        stats = save_releases(engine, [_api_item(VSOItem=_VSO_URL)])
+
+        row = _fetch(engine)
+        assert row.vso_item == _VSO_URL
+        assert stats["updated"] == 1
+
+    def test_releaseitem_dataclass_path_preserves_existing_vso(self, engine):
+        # Regression: the production code path runs items through
+        # ReleaseItem.from_dict before save_releases. Ensure stickiness
+        # works there too.
+        from lib.release_item import ReleaseItem
+
+        seeded_hash = _seed(engine, vso_item=_VSO_URL)
+
+        item_dict = _api_item()
+        del item_dict["VSOItem"]
+        items = [ReleaseItem.from_dict(item_dict)]
+        stats = save_releases(engine, items)
+
+        row = _fetch(engine)
+        assert row.vso_item == _VSO_URL
+        assert row.row_hash == seeded_hash
+        assert stats["unchanged"] == 1


### PR DESCRIPTION
## Hotfix: stickiness was bypassed on the production code path

The previous hotfix (#86) added a "stickiness" rule in `save_releases`
that should keep an existing `release_date` whenever it falls inside the
new quarter, so the `"Q4 2024"` source switch wouldn't churn
`row_hash` / `last_modified` / re-vectorization. The dry-run preview
script confirmed this against prod (874 / 874 rows kept).

But when the container actually ran `get_current_releases.py`, **every
single row was rewritten**.

### Root cause

The container path is:

```
raw API dict
  -> ReleaseItem.from_dict(d)        # parses ReleaseDate to a `date`
  -> save_releases(engine, items)
```

Inside `save_releases`, the stickiness check did:

```python
raw_release_date = _get(item, "ReleaseDate", "release_date")
bounds = _quarter_bounds(raw_release_date)
```

`ReleaseItem` has no `ReleaseDate` attribute, so `_get` fell back to
`release_date` — which by then was already a parsed `date(2024, 12, 31)`
object. `_quarter_bounds` only matches `"Q# YYYY"` strings, so it
returned `None`, stickiness was silently skipped, and every row got
re-stamped to the quarter-end date.

The dry-run preview script worked because it operated on the raw API
dicts directly (where `"ReleaseDate"` is still the string `"Q4 2024"`).

### Fix

- Add `ReleaseItem.release_date_raw: Optional[str]` to retain the
  unparsed source string.
- `save_releases` now reads the raw value via
  `_get(item, "ReleaseDate", "release_date_raw")` so both raw dicts
  (`"ReleaseDate"` key) and `ReleaseItem` instances
  (`release_date_raw` attr) resolve correctly.

### Tests

Added two regression tests in `tests/test_save_releases_quarter.py`
that go through `ReleaseItem.from_dict(...)` end-to-end against
`save_releases`:

- `test_releaseitem_dataclass_path_preserves_existing_in_quarter`
- `test_releaseitem_dataclass_path_overwrites_when_outside_quarter`

The original tests passed dicts directly, which is why they didn't
catch this — the new tests exercise the actual production path.

Full suite: 423 passing.
